### PR TITLE
Added APNG generation for character sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ log_error.txt
 log.txt
 sponsor_logos/*
 !sponsor_logos/*.txt
+assets/characters.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 py7zr
 deepdiff
 qdarkstyle
+pillow

--- a/src/Helpers/TSHCountryHelper.py
+++ b/src/Helpers/TSHCountryHelper.py
@@ -22,7 +22,8 @@ class TSHCountryHelper():
         return u"".join([c for c in nfkd_form if not unicodedata.combining(c)]).lower()
 
     def LoadCountries():
-        f = open("./assets/countries+states+cities.json", 'r', encoding='utf-8')
+        f = open("./assets/countries+states+cities.json",
+                 'r', encoding='utf-8')
         countries_json = json.loads(f.read())
 
         for c in countries_json:

--- a/src/Helpers/TSHCountryHelper.py
+++ b/src/Helpers/TSHCountryHelper.py
@@ -22,7 +22,7 @@ class TSHCountryHelper():
         return u"".join([c for c in nfkd_form if not unicodedata.combining(c)]).lower()
 
     def LoadCountries():
-        f = open("./assets/countries+states+cities.json", 'r')
+        f = open("./assets/countries+states+cities.json", 'r', encoding='utf-8')
         countries_json = json.loads(f.read())
 
         for c in countries_json:

--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -28,7 +28,7 @@ class StateManager:
                 assets = characters.get(character_key).get("assets")
                 for asset_key in assets.keys():
                     asset_type = assets.get(asset_key).get("type")[0]
-                    asset_path = assets.get(asset_key).get("image")
+                    asset_path = assets.get(asset_key).get("asset")
                     if sources.get(asset_type):
                         sources[asset_type].append(asset_path)
                     else:

--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -28,15 +28,15 @@ class StateManager:
                 assets = characters.get(character_key).get("assets")
                 for asset_key in assets.keys():
                     asset_type = assets.get(asset_key).get("type")[0]
-                    asset_path = assets.get(asset_key).get("path")
+                    asset_path = assets.get(asset_key).get("image")
                     if sources.get(asset_type):
                         sources[asset_type].append(asset_path)
                     else:
                         sources[asset_type] = [asset_path]
 
         for asset_type in sources.keys():
-            apng_name = f"{team_key}_player{player_key}_{asset_type}_apng"
-            out_folder = './out/score'
+            apng_name = f"{asset_type}_apng"
+            out_folder = f'./out/score/{team_key}/players/{player_key}/character'
             apng_path = f"{out_folder}/{apng_name}.png"
             html_path = f"{out_folder}/{apng_name}.html"
 

--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -12,7 +12,7 @@ from Helpers.TSHDictHelper import deep_get, deep_set, deep_unset
 class StateManager:
     state = {}
 
-    def SavePlayerAPNG(team_key:str, player_key:str):
+    def SavePlayerAPNG(team_key: str, player_key: str):
         print(f"Player {player_key}")
 
         duration = 10000  # in milliseconds
@@ -50,8 +50,8 @@ class StateManager:
                 for i in asset_list:
                     new_frame = Image.open(i).convert('RGBA')
                     frames.append(new_frame)
-                
-                max_width , max_height = 0,0
+
+                max_width, max_height = 0, 0
                 for i in range(len(frames)):
                     width, height = frames[i].size
                     if width > max_width:
@@ -64,19 +64,21 @@ class StateManager:
                     if width != max_width or height != max_height:
                         ratio = min(max_width/width, max_height/height)
                         print(ratio)
-                        frames[i]=frames[i].resize((int(width*ratio), int(height*ratio)), Image.ANTIALIAS)
+                        frames[i] = frames[i].resize(
+                            (int(width*ratio), int(height*ratio)), Image.ANTIALIAS)
 
-                        new_image = Image.new('RGBA', (max_height, max_width), (0, 0, 0, 0))
+                        new_image = Image.new(
+                            'RGBA', (max_height, max_width), (0, 0, 0, 0))
                         upper = (max_height - int(height*ratio)) // 2
-                        left = (max_width - int(width*ratio)) //2
-                        new_image.paste(frames[i], (left,upper))
+                        left = (max_width - int(width*ratio)) // 2
+                        new_image.paste(frames[i], (left, upper))
                         frames[i] = new_image
 
                 frames[0].save(apng_path, format='PNG',
-                append_images=frames[1:],
-                save_all=True,
-                duration=len_slide, loop=0)
-                
+                               append_images=frames[1:],
+                               save_all=True,
+                               duration=len_slide, loop=0)
+
                 html_contents = f'<img src="{apng_name}.png">'
                 with open(html_path, 'wt', encoding='utf-8') as html_file:
                     html_file.write(html_contents)


### PR DESCRIPTION
- Added generation of an APNG file for character sets
  - Uses the `pillow` library
  - Generates both an APNG with all of the characters and an HTML file which can be imported in OBS as a Browser Source
  - If the asset files have mismatched sizes, the APNG generator will resize files to the highest resolution while maintaining the aspect ratio
  - The APNG generator routine is ran every time there is a state change for now so it is not the most optimized behavior
  - APNG duration is currently hardcoded to 10 seconds
- Fixed an issue where the program wouldn't load `./assets/countries+states+cities.json` properly