### PR TITLE
Change Reset Score Button to not reset match and phase

### DIFF
--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -469,8 +469,6 @@ class TSHScoreboardWidget(QDockWidget):
         self.teamsSwapped = not self.teamsSwapped
 
     def ResetScore(self):
-        self.scoreColumn.findChild(QComboBox, "match").setCurrentText("")
-        self.scoreColumn.findChild(QComboBox, "phase").setCurrentText("")
         self.scoreColumn.findChild(QSpinBox, "score_left").setValue(0)
         self.scoreColumn.findChild(QSpinBox, "score_right").setValue(0)
 


### PR DESCRIPTION
In reference to #74.

This simply drops the 2 lines in the reset score call that also resets the match and phase to blank. In a later release we can look to introduce a reset match button that'll clear out the phase and match as well, but this is more for a quick fix and release to get it out there.