### PR TITLE
Add PyInstaller 4.10 specific versioning

### DIFF
--- a/.github/workflows/gen_windows_release.yml
+++ b/.github/workflows/gen_windows_release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: "3.8"
 
-      - run: pip install -r dependencies/requirements.txt pyinstaller
+      - run: pip install -r dependencies/requirements.txt pyinstaller==4.10
       - run: |
           set PYTHONUTF8=1
           chcp 65001


### PR DESCRIPTION
Apparently PyInstaller released 5.0 and it's breaking building for the moment, so this should fix it.

Something always has to ruin the party.