### PR TITLE
Changed score up and down for Web Server

### DIFF
--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -68,21 +68,25 @@ class WebServer(QThread):
     # Ticks score of Team specified up by 1 point
     @app.route('/team<team>-scoreup')
     def team_scoreup(team):
-        score = {'team' + team +'score': StateManager.Get(f"score.team." + team + ".score") + 1}
-        WebServer.scoreboard.signals.UpdateSetData.emit(eval(json.dumps(score)))
+        if team == "1":
+            WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_left").setValue(WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_left").value() + 1)
+        else:
+            WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").setValue(WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").value() + 1)
         return "OK"
     
     # Ticks score of Team specified down by 1 point
     @app.route('/team<team>-scoredown')
     def team_scoredown(team):
-        if StateManager.Get(f"score.team." + team + ".score") - 1 < 1:
-            if team == "1":
+        if team == "1":
+            if WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_left").value() -1 < 1:
                 WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_left").setValue(0)
             else:
-                WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").setValue(0)
+                WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_left").setValue(WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_left").value() - 1)
         else:
-            score = {'team' + team +'score': StateManager.Get(f"score.team." + team + ".score") - 1}
-            WebServer.scoreboard.signals.UpdateSetData.emit(eval(json.dumps(score)))
+            if WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").value() -1 < 1:
+                WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").setValue(0)
+            else:
+                WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").setValue(WebServer.scoreboard.scoreColumn.findChild(QSpinBox, "score_right").value() - 1)
         return "OK"
     
     # Dynamic endpoint to allow flexible sets of information


### PR DESCRIPTION
One of my team members informed me of an edge case that could happen when using score up and down when swapping teams that could cause team 2 score up to affect team one and vice versa. This appeared to be linked more towards the State Manager getting confused when swapping players, but can't technically reproduce without the Web Server endpoints being used, so I've updated the calls to directly change the widgets to be more reliable in that aspect.