### PR TITLE
Added Phase data and Round name to Recent Sets Query

### DIFF
--- a/src/TournamentDataProvider/SmashGGDataProvider.py
+++ b/src/TournamentDataProvider/SmashGGDataProvider.py
@@ -662,6 +662,15 @@ class SmashGGDataProvider(TournamentDataProvider):
                 sets = deep_get(event, "sets.nodes")
 
                 for _set in sets:
+                    phaseName = ""
+                    phaseIdentifier = ""
+                    
+                    # This is because a display identifier at a major (Ex. Pools C12) will return C12,
+                    # otherwise SmashGG will just return a string containing "1"
+                    if deep_get(_set, "phaseGroup.displayIdentifier") != "1":
+                        phaseIdentifier = deep_get(_set, "phaseGroup.displayIdentifier") 
+                    phaseName = deep_get(_set, "phaseGroup.phase.name")
+
                     p1id = _set.get("slots", [{}])[0].get("entrant", {}).get(
                         "participants", [{}])[0].get("player", {}).get("id")
                     p2id = _set.get("slots", [{}])[1].get("entrant", {}).get(
@@ -717,7 +726,10 @@ class SmashGGDataProvider(TournamentDataProvider):
                         "online": event.get("isOnline"),
                         "score": score,
                         "timestamp": event.get("startAt"),
-                        "winner": winner
+                        "winner": winner,
+                        "round": _set.get("fullRoundText"),
+                        "phase_name": phaseName,
+                        "phase_id": phaseIdentifier
                     }
                     recentSets.append(entry)
             return recentSets

--- a/src/TournamentDataProvider/SmashGGRecentSetsQuery.txt
+++ b/src/TournamentDataProvider/SmashGGRecentSetsQuery.txt
@@ -25,6 +25,13 @@ query RecentSetsQuery($pid1: ID!, $pid2: ID!, $uid1: ID!, $uid2: ID! $page: Int!
                         entrant1Score
                         entrant2Score
                         winnerId
+        				fullRoundText
+                        phaseGroup {
+            				displayIdentifier
+            				phase {
+              					name
+            				}
+       					}
                     }
                 }
             }

--- a/src/TournamentDataProvider/SmashGGRecentSetsQuery.txt
+++ b/src/TournamentDataProvider/SmashGGRecentSetsQuery.txt
@@ -25,12 +25,12 @@ query RecentSetsQuery($pid1: ID!, $pid2: ID!, $uid1: ID!, $uid2: ID! $page: Int!
                         entrant1Score
                         entrant2Score
                         winnerId
-        				fullRoundText
+                        fullRoundText
                         phaseGroup {
-            				displayIdentifier
-            				phase {
-              					name
-            				}
+                            displayIdentifier
+                            phase {
+                                name
+                            }
        					}
                     }
                 }


### PR DESCRIPTION
This PR addresses #102 with adding the ability to grab phase data and the round name and add it into the recent_sets overlay. Coming up with a proper layout for recent_sets will be something that I work with Shino on, but this gives the ability for pulling the information at least.