### PR TITLE
Various fixes for new thumbnail generator

### DIFF
--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -718,7 +718,7 @@ def generate(settingsManager, isPreview=False):
     foreground = foreground.scaled(
         background.width(),
         background.height(),
-        Qt.AspectRatioMode.KeepAspectRatio,
+        Qt.AspectRatioMode.IgnoreAspectRatio,
         Qt.TransformationMode.SmoothTransformation
     )
 
@@ -753,7 +753,7 @@ def generate(settingsManager, isPreview=False):
         tag_player2 = find("score.team.2.player.1.name", data)
         thumbnail_filename = f"{tag_player1}-vs-{tag_player2}-{datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M-%S')}"
         thumbnail.save(f"{out_path}/{thumbnail_filename}.png")
-        thumbnail.convert("RGB").save(f"{out_path}/{thumbnail_filename}.jpg")
+        thumbnail.save(f"{out_path}/{thumbnail_filename}.jpg")
         if os.path.isdir(tmp_path):
             shutil.rmtree(tmp_path)
         print(


### PR DESCRIPTION
- Fixed saving error when saving to JPG
- Reverted foreground behavior to original behavior (aspect ratio is ignored when scaling the foreground to the background)

![Kyo-vs-Isla-2022-05-06-07-17-37](https://user-images.githubusercontent.com/1964201/167085723-c081ebe0-f24d-40c0-abaf-9e7de7f9a970.png)