### PR TITLE
Bug Fix: Fix Challonge Regular Expression to Support Challonge Urls

### DIFF
--- a/src/TSHTournamentDataProvider.py
+++ b/src/TSHTournamentDataProvider.py
@@ -88,7 +88,7 @@ class TSHTournamentDataProvider:
         okButton = QPushButton("OK")
         validators = [
             QRegularExpression("start.gg/tournament/[^/]+/event/[^/]+"),
-            QRegularExpression("challonge.com/.+/.+")
+            QRegularExpression("challonge.com/.+")
         ]
 
         def validateText():


### PR DESCRIPTION
Current challonge urls are now `challonge.com/<tournament>`.
This PR updates the Regular Expression to allow users to use Challonge again.
Current regular expression prevents users from using their tournaments because the regular expression is expecting another subdirectory, therefore locking users from hitting `Ok` to `Set Tournament`.