### PR TITLE
Minor Change: Centered Phase and Match in VGBC Overlay

### DIFF
--- a/layout/scoreboard_vgbootcampy/index.css
+++ b/layout/scoreboard_vgbootcampy/index.css
@@ -91,7 +91,7 @@ body {
   box-sizing: border-box;
   overflow: hidden;
   background: var(--bg-color);
-  margin-bottom: 16px;
+  margin-bottom: 17px;
 }
 
 .p1 .inner_container {


### PR DESCRIPTION
A really minor update: Increased padding-bottom of inner container from 16px to 17px to center phase and match properly within their container.