### PR TITLE
Thumbnail generator improvements

### DIFF
--- a/src/TSHThumbnailSettingsWidget.py
+++ b/src/TSHThumbnailSettingsWidget.py
@@ -93,7 +93,10 @@ class TSHThumbnailSettingsWidget(QDockWidget):
         game_codename = TSHGameAssetManager.instance.selectedGame.get(
             "codename")
         if game_codename:
+            self.zoom.setEnabled(True)
             self.zoom.setValue(settings.get(f"zoom/{game_codename}", 100))
+        else:
+            self.zoom.setEnabled(False)
 
     def setDefaults(self, button_mode=False):
         settings = {
@@ -557,9 +560,13 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                 if game_codename:
                     self.selectRenderType.setCurrentIndex(self.selectRenderType.findText(
                         asset_dict[settings[f"asset/{game_codename}"]]))
+                    self.selectRenderType.setEnabled(True)
+                    self.zoom.setEnabled(True)
                     self.zoom.setValue(
                         settings.get(f"zoom/{game_codename}", 100))
                 else:
+                    self.zoom.setEnabled(False)
+                    self.selectRenderType.setEnabled(False)
                     self.selectRenderType.setCurrentIndex(0)
             except KeyError:
                 if "full" in asset_dict.keys():
@@ -576,6 +583,12 @@ class TSHThumbnailSettingsWidget(QDockWidget):
             try:
                 game_codename = TSHGameAssetManager.instance.selectedGame.get(
                     "codename")
+                if not game_codename:
+                    self.selectRenderType.setEnabled(False)
+                    self.zoom.setEnabled(False)
+                else:
+                    self.selectRenderType.setEnabled(True)
+                    self.zoom.setEnabled(True)
                 TSHThumbnailSettingsWidget.SaveSettings(
                     self, key=f"zoom/{game_codename}", val=self.zoom.value(), generatePreview=True)
             except Exception as e:
@@ -586,6 +599,12 @@ class TSHThumbnailSettingsWidget(QDockWidget):
             try:
                 game_codename = TSHGameAssetManager.instance.selectedGame.get(
                     "codename")
+                if not game_codename:
+                    self.zoom.setEnabled(False)
+                    self.selectRenderType.setEnabled(False)
+                else:
+                    self.zoom.setEnabled(True)
+                    self.selectRenderType.setEnabled(True)
                 if self.selectRenderType.currentData():
                     TSHThumbnailSettingsWidget.SaveSettings(
                         self, key=f"asset/{game_codename}", val=self.selectRenderType.currentData(), generatePreview=True)

--- a/src/TSHThumbnailSettingsWidget.py
+++ b/src/TSHThumbnailSettingsWidget.py
@@ -532,7 +532,7 @@ class TSHThumbnailSettingsWidget(QDockWidget):
         if (TSHGameAssetManager.instance.selectedGame.get("name")):
             game_name = TSHGameAssetManager.instance.selectedGame.get("name")
         else:
-            game_name = "(No game selected)"
+            game_name = QApplication.translate("Form", "(No game selected)")
         label_text = f'<html><head/><body><p><span style=" font-weight:700;">{game_name}</span></p></body></html>'
         self.selectRenderLabel.setText(label_text)
         if (TSHGameAssetManager.instance.selectedGame.get("assets")):

--- a/src/layout/TSHThumbnailSettings.ui
+++ b/src/layout/TSHThumbnailSettings.ui
@@ -353,46 +353,6 @@
               </widget>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_11">
-               <item>
-                <widget class="QLabel" name="label_14">
-                 <property name="text">
-                  <string>Zoom</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="zoom">
-                 <property name="suffix">
-                  <string>%</string>
-                 </property>
-                 <property name="maximum">
-                  <number>1000</number>
-                 </property>
-                 <property name="value">
-                  <number>100</number>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item>
               <spacer name="verticalSpacer_3">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
@@ -747,6 +707,36 @@
            </item>
           </layout>
          </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_11">
+               <item>
+                <widget class="QLabel" name="label_14">
+                 <property name="text">
+                  <string>Zoom</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeft</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="zoom">
+                 <property name="suffix">
+                  <string>%</string>
+                 </property>
+                 <property name="maximum">
+                  <number>1000</number>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="value">
+                  <number>100</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
          <item>
           <widget class="Line" name="line_5">
            <property name="orientation">

--- a/src/layout/TSHThumbnailSettings.ui
+++ b/src/layout/TSHThumbnailSettings.ui
@@ -707,36 +707,64 @@
            </item>
           </layout>
          </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_11">
-               <item>
-                <widget class="QLabel" name="label_14">
-                 <property name="text">
-                  <string>Zoom</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignLeft</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="zoom">
-                 <property name="suffix">
-                  <string>%</string>
-                 </property>
-                 <property name="maximum">
-                  <number>1000</number>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="value">
-                  <number>100</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+           <item>
+            <widget class="QLabel" name="label_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Zoom</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeft</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Maximum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="zoom">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>%</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>1000</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item>
           <widget class="Line" name="line_5">
            <property name="orientation">

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -160,7 +160,7 @@ def resize_image_to_max_size(image: QPixmap, max_size, eyesight_coordinates=None
             left = 0
             right = max_size[0]
         if ("right" in crop_borders):
-            right = new_x
+            right = max_size[0]
             left = new_x - max_size[0]
     if max_size[1] > new_y:
         top = round(-(max_size[1] - new_y)/2)
@@ -169,7 +169,7 @@ def resize_image_to_max_size(image: QPixmap, max_size, eyesight_coordinates=None
             top = 0
             bottom = max_size[1]
         if ("bottom" in crop_borders):
-            bottom = new_y
+            bottom = max_size[1]
             top = new_y - max_size[1]
 
     new_image = create_composite_image(new_image, QSize(max_size[0], max_size[1]), (-left, -top))

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -27,6 +27,7 @@ use_team_names = False
 use_sponsors = True
 all_eyesight = False
 
+crop_borders = [] # left, right, top, bottom
 
 def color_code_to_tuple(color_code):
     raw_color_code = color_code.lstrip("#")
@@ -103,21 +104,30 @@ def resize_image_to_max_size(image: QPixmap, max_size, eyesight_coordinates=None
             msg=f"Size cannot be negative, given max size is {max_size}")
 
     resized_eyesight = None
-    if (x_ratio < y_ratio and fill_x and fill_y) or (fill_y and not fill_x) or ((not fill_x) and (not fill_y) and (x_ratio > y_ratio)):
-        new_x = y_ratio*current_size.width()*zoom
-        new_y = max_size[1]*zoom
-        if eyesight_coordinates:
-            resized_eyesight = (
-                round(eyesight_coordinates[0]*y_ratio*zoom), round(eyesight_coordinates[1]*y_ratio*zoom))
-    else:
-        new_x = max_size[0]*zoom
-        new_y = x_ratio*current_size.height()*zoom
-        if eyesight_coordinates:
-            resized_eyesight = (
-                round(eyesight_coordinates[0]*x_ratio*zoom), round(eyesight_coordinates[1]*x_ratio*zoom))
+    effective_zoom = zoom
+    zoom_step = 0.01
+    zoom_flag = False
+    while not zoom_flag:
+        if (x_ratio < y_ratio):
+            new_x = y_ratio*current_size.width()*effective_zoom
+            new_y = max_size[1]*effective_zoom
+            if eyesight_coordinates:
+                resized_eyesight = (
+                    round(eyesight_coordinates[0]*y_ratio*effective_zoom), round(eyesight_coordinates[1]*y_ratio*effective_zoom))
+        else:
+            new_x = max_size[0]*effective_zoom
+            new_y = x_ratio*current_size.height()*effective_zoom
+            if eyesight_coordinates:
+                resized_eyesight = (
+                    round(eyesight_coordinates[0]*x_ratio*effective_zoom), round(eyesight_coordinates[1]*x_ratio*effective_zoom))
+        if not(new_x < max_size[0] and ("left" in crop_borders) and ("right" in crop_borders)):
+            if not(new_y < max_size[1] and ("top" in crop_borders) and ("bottom" in crop_borders)):
+                zoom_flag = True
+        if not zoom_flag:
+            effective_zoom += zoom_step
 
     new_size = (round(new_x), round(new_y))
-    image = image.scaled(
+    new_image = image.scaled(
         new_size[0], new_size[1], transformMode=Qt.TransformationMode.SmoothTransformation)
 
     # crop
@@ -143,21 +153,28 @@ def resize_image_to_max_size(image: QPixmap, max_size, eyesight_coordinates=None
         if bottom > new_y:
             bottom = new_y
             top = new_y - max_size[1]
-        if max_size[0] > new_x:
-            left = round(-(max_size[0] - new_x)/2)
-            right = round((max_size[0] + new_x)/2)
-        if max_size[1] > new_y:
-            top = round(-(max_size[1] - new_y)/2)
-            bottom = round((max_size[1] + new_y)/2)
+    if max_size[0] > new_x:
+        left = round(-(max_size[0] - new_x)/2)
+        right = round((max_size[0] + new_x)/2)
+        if ("left" in crop_borders):
+            left = 0
+            right = max_size[0]
+        if ("right" in crop_borders):
+            right = new_x
+            left = new_x - max_size[0]
+    if max_size[1] > new_y:
+        top = round(-(max_size[1] - new_y)/2)
+        bottom = round((max_size[1] + new_y)/2)
+        if ("top" in crop_borders):
+            top = 0
+            bottom = max_size[1]
+        if ("bottom" in crop_borders):
+            bottom = new_y
+            top = new_y - max_size[1]
 
-    image = image.copy(
-        int(left),
-        int(top),
-        int(right-left),
-        int(bottom-top)
-    )
+    new_image = create_composite_image(new_image, QSize(max_size[0], max_size[1]), (-left, -top))
 
-    return(image)
+    return(new_image)
 
 
 def create_composite_image(image, size, coordinates):


### PR DESCRIPTION
- Fixed issue https://github.com/joaorb64/TournamentStreamHelper/issues/186: The assets are now centered by default if the zoom is smaller than 100%
- Added code to constrain the asset to certain borders if the scaled asset is smaller than the canvas
  - To be used in a future feature, needs to be connected to the proper data. In this PR, the asset will not be constrained.

![Screenshot_870](https://user-images.githubusercontent.com/1964201/188217111-cae04320-b73f-4a2d-84d2-118968eef5ab.png)
*Example of an asset with constraining borders on the left, right and bottom*

- Fixed an issue where the `(No game selected)` text in the UI would appear untranslated when resetting default settings for thumbnails
- Moved zoom option in the thumbnail settings tab