### PR TITLE
Added Short Link Functionality to TSH Tournament Info

### DIFF
--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -69,6 +69,8 @@ class StartGGDataProvider(TournamentDataProvider):
                 data, "data.event.numEntrants", 0)
             finalData["address"] = deep_get(
                 data, "data.event.tournament.venueAddress", "")
+            finalData["shortLink"] = deep_get(
+                data, "data.event.tournament.shortSlug", "")
         except:
             traceback.print_exc()
 

--- a/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
@@ -10,6 +10,7 @@ query TournamentDataQuery($eventSlug: String!) {
     numEntrants
     tournament {
         name
+        shortSlug
         venueAddress
     }
   }

--- a/src/layout/TSHTournamentInfo.ui
+++ b/src/layout/TSHTournamentInfo.ui
@@ -41,11 +41,12 @@
       <property name="bottomMargin">
        <number>9</number>
       </property>
-      <item row="3" column="1">
-       <widget class="QLineEdit" name="address"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="eventName"/>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Tournament Name</string>
+        </property>
+       </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="label_4">
@@ -57,12 +58,25 @@
       <item row="0" column="1">
        <widget class="QLineEdit" name="tournamentName"/>
       </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="address"/>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Event Name</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Entrant Number</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="eventName"/>
       </item>
       <item row="2" column="1">
        <widget class="QSpinBox" name="numEntrants">
@@ -71,17 +85,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tournament Name</string>
-        </property>
-       </widget>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="shortLink"/>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>Entrant Number</string>
+         <string>Short Link</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Basic PR that adds the ability to display and store the short link of the current selected event if the current event has one established, otherwise it'll return as blank. Should allow for a little bit more creativity in layouts with displaying event info.

**NOTE:** The new label for the QT layout will need translations for other languages to support the multi-language feature of TSH.