### PR TITLE
Upgraded Player ID Signals to Support Individual Changes

### DIFF
--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -16,6 +16,8 @@ from .Helpers.TSHLocaleHelper import TSHLocaleHelper
 class TSHScoreboardPlayerWidgetSignals(QObject):
     characters_changed = pyqtSignal()
     playerId_changed = pyqtSignal()
+    player1Id_changed = pyqtSignal()
+    player2Id_changed = pyqtSignal()
 
 
 class TSHScoreboardPlayerWidget(QGroupBox):
@@ -241,6 +243,10 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             StateManager.Set(
                 f"{self.path}.id", id)
             self.instanceSignals.playerId_changed.emit()
+            if self.path.startswith("score.team.1"):
+                self.instanceSignals.player1Id_changed.emit()
+            else:
+                self.instanceSignals.player2Id_changed.emit()
 
     def SwapWith(self, other: "TSHScoreboardPlayerWidget"):
         tmpData = []

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -489,7 +489,7 @@ class TSHScoreboardWidget(QDockWidget):
                 self.team1playerWidgets[index+1 if index < len(self.team1playerWidgets) - 1 else index]))
 
             p.instanceSignals.playerId_changed.connect(self.GetRecentSets)
-            p.instanceSignals.playerId_changed.connect(self.GetLastSets)
+            p.instanceSignals.player1Id_changed.connect(self.GetLastSetsP1)
 
             self.team1playerWidgets.append(p)
 
@@ -510,7 +510,7 @@ class TSHScoreboardWidget(QDockWidget):
                 self.team2playerWidgets[index+1 if index < len(self.team2playerWidgets) - 1 else index]))
 
             p.instanceSignals.playerId_changed.connect(self.GetRecentSets)
-            p.instanceSignals.playerId_changed.connect(self.GetLastSets)
+            p.instanceSignals.player2Id_changed.connect(self.GetLastSetsP2)
 
             self.team2playerWidgets.append(p)
 
@@ -639,17 +639,22 @@ class TSHScoreboardWidget(QDockWidget):
                 "request_time": data.get("request_time")
             })
     
-    def GetLastSets(self):
+    def GetLastSetsP1(self):
         # Only if 1 player on each side
         if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
             p1id = StateManager.Get(f"score.team.1.player.1.id")
-            p2id = StateManager.Get(f"score.team.2.player.1.id")
-
-            if p1id and p2id and json.dumps(p1id) != json.dumps(p2id):
+            if p1id:
                 TSHTournamentDataProvider.instance.GetLastSets(p1id, "1")
-                TSHTournamentDataProvider.instance.GetLastSets(p2id, "2")
             else:
                 StateManager.Set(f"score.last_sets.1", {})
+    
+    def GetLastSetsP2(self):
+        # Only if 1 player on each side
+        if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
+            p2id = StateManager.Get(f"score.team.2.player.1.id")
+            if p2id:
+                TSHTournamentDataProvider.instance.GetLastSets(p2id, "2")
+            else:
                 StateManager.Set(f"score.last_sets.2", {})
     
     def UpdateLastSets(self, data):


### PR DESCRIPTION
This was always bothering me with the last sets PR I made that I couldn't make it originally per player to grab the stats and that I had to make it require both players before it could make the call.

Now after a couple weeks of brainstorming and realizing my mistake, I present this PR! This PR fixes my original issue with last sets and opens the doors to even more flexibility when it comes to adding features that can be individualized per player, such as, last sets, player tournament standings (keep an eye out for this one ;D ), and other cool features of the like! It allows features to be closer developed on a per player basis than an overall requirement of deciphering which ID changed where and what all is happening. This makes it simple by adding a player1ID and player2ID signal to react based upon that could allow for some cool stuff.