### PR TITLE
Shifted Stats Functions to Separate Utility Class

### DIFF
--- a/layout/tournament_history/index.js
+++ b/layout/tournament_history/index.js
@@ -83,7 +83,7 @@
           gsap.from(
             $(`.tournament${s + 1}`),
             { y: +100, autoAlpha: 0, duration: 0.3 },
-            0.2 + 0.2 * s
+            (0.2 + 0.2 * s) + gsap.timeline().time()
           );
         });
     }

--- a/src/TSHPlayerDB.py
+++ b/src/TSHPlayerDB.py
@@ -22,7 +22,7 @@ class TSHPlayerDB:
     database = {}
     model: QStandardItemModel = None
     fieldnames = ["prefix", "gamerTag", "name", "twitter",
-                  "country_code", "state_code", "mains", "pronoun"]
+                  "country_code", "state_code", "mains", "pronoun", "seed"]
     modelLock = Lock()
 
     def LoadDB():

--- a/src/TSHPlayerDB.py
+++ b/src/TSHPlayerDB.py
@@ -22,7 +22,7 @@ class TSHPlayerDB:
     database = {}
     model: QStandardItemModel = None
     fieldnames = ["prefix", "gamerTag", "name", "twitter",
-                  "country_code", "state_code", "mains", "pronoun", "seed"]
+                  "country_code", "state_code", "mains", "pronoun"]
     modelLock = Lock()
 
     def LoadDB():

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -741,6 +741,9 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                             color_element.setCurrentIndex(int(main[1]))
                         else:
                             color_element.setCurrentIndex(0)
+        
+        if data.get("seed"):
+            StateManager.Set(f"{self.path}.seed", data.get("seed"))
                             
         StateManager.ReleaseSaving()
 

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -13,6 +13,7 @@ from .SettingsManager import *
 from .StateManager import *
 from .TSHTournamentDataProvider import TSHTournamentDataProvider
 from .TSHScoreboardStageWidget import TSHScoreboardStageWidget
+from .TSHStatsUtil import TSHStatsUtil
 
 from .thumbnail import main_generate_thumbnail as thumbnail
 from .TSHThumbnailSettingsWidget import *
@@ -42,6 +43,8 @@ class TSHScoreboardWidget(QDockWidget):
         self.signals.SetSelection.connect(self.LoadSetClicked)
         self.signals.StreamSetSelection.connect(self.LoadStreamSetClicked)
         self.signals.UserSetSelection.connect(self.LoadUserSetClicked)
+
+        TSHStatsUtil.instance.scoreboard = self
 
         self.lastSetSelected = None
 
@@ -362,15 +365,6 @@ class TSHScoreboardWidget(QDockWidget):
         self.scoreColumn.findChild(
             QPushButton, "btResetScore").setIcon(QIcon('assets/icons/undo.svg'))
 
-        TSHTournamentDataProvider.instance.signals.recent_sets_updated.connect(
-            self.UpdateRecentSets)
-
-        TSHTournamentDataProvider.instance.signals.last_sets_updated.connect(
-            self.UpdateLastSets)
-
-        TSHTournamentDataProvider.instance.signals.history_sets_updated.connect(
-            self.UpdateHistorySets)
-
         # Add default and user tournament phase title files
         self.scoreColumn.findChild(QComboBox, "phase").addItem("")
         default_tournament_phases_file = './assets/tournament_phases.txt'
@@ -491,9 +485,12 @@ class TSHScoreboardWidget(QDockWidget):
             p.btMoveDown.clicked.connect(lambda x, index=index, p=p: p.SwapWith(
                 self.team1playerWidgets[index+1 if index < len(self.team1playerWidgets) - 1 else index]))
 
-            p.instanceSignals.playerId_changed.connect(self.GetRecentSets)
-            p.instanceSignals.player1Id_changed.connect(self.GetLastSetsP1)
-            p.instanceSignals.player1Id_changed.connect(self.GetPlayerHistoryStandingsP1)
+            p.instanceSignals.playerId_changed.connect(
+                TSHStatsUtil.instance.signals.RecentSetsSignal.emit)
+            p.instanceSignals.player1Id_changed.connect(
+                TSHStatsUtil.instance.signals.LastSetsP1Signal.emit)
+            p.instanceSignals.player1Id_changed.connect(
+                TSHStatsUtil.instance.signals.PlayerHistoryStandingsP1Signal.emit)
 
             self.team1playerWidgets.append(p)
 
@@ -513,9 +510,12 @@ class TSHScoreboardWidget(QDockWidget):
             p.btMoveDown.clicked.connect(lambda x, index=index, p=p: p.SwapWith(
                 self.team2playerWidgets[index+1 if index < len(self.team2playerWidgets) - 1 else index]))
 
-            p.instanceSignals.playerId_changed.connect(self.GetRecentSets)
-            p.instanceSignals.player2Id_changed.connect(self.GetLastSetsP2)
-            p.instanceSignals.player2Id_changed.connect(self.GetPlayerHistoryStandingsP2)
+            p.instanceSignals.playerId_changed.connect(
+                TSHStatsUtil.instance.signals.RecentSetsSignal.emit)
+            p.instanceSignals.player2Id_changed.connect(
+                TSHStatsUtil.instance.signals.LastSetsP2Signal.emit)
+            p.instanceSignals.player2Id_changed.connect(
+                TSHStatsUtil.instance.signals.PlayerHistoryStandingsP2Signal.emit)
 
             self.team2playerWidgets.append(p)
 
@@ -614,104 +614,6 @@ class TSHScoreboardWidget(QDockWidget):
 
         StateManager.Set(f"score.teamsSwapped", self.teamsSwapped)
 
-        StateManager.ReleaseSaving()
-
-    def GetRecentSets(self):
-        updated = False
-        # Only if 1 player on each side
-        if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
-            p1id = StateManager.Get(f"score.team.1.player.1.id")
-            p2id = StateManager.Get(f"score.team.2.player.1.id")
-            if p1id and p2id and json.dumps(p1id) != json.dumps(p2id):
-                StateManager.Set(f"score.recent_sets", {
-                    "state": "loading",
-                    "sets": []
-                })
-                TSHTournamentDataProvider.instance.GetRecentSets(p1id, p2id)
-                updated = True
-
-        if not updated:
-            StateManager.Set(f"score.recent_sets", {
-                "state": "done",
-                "sets": []
-            })
-
-    def UpdateRecentSets(self, data):
-        lastUpdateTime = StateManager.Get(f"score.recent_sets.request_time", 0)
-
-        if data.get("request_time", 0) > lastUpdateTime:
-            StateManager.Set(f"score.recent_sets", {
-                "state": "done",
-                "sets": data.get("sets"),
-                "request_time": data.get("request_time")
-            })
-    
-    def GetLastSetsP1(self):
-        # Only if 1 player on each side
-        if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance:
-            p1id = StateManager.Get(f"score.team.1.player.1.id")
-            if p1id:
-                TSHTournamentDataProvider.instance.GetLastSets(p1id, "1")
-            else:
-                StateManager.Set(f"score.last_sets.1", {})
-    
-    def GetLastSetsP2(self):
-        # Only if 1 player on each side
-        if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance:
-            p2id = StateManager.Get(f"score.team.2.player.1.id")
-            if p2id:
-                TSHTournamentDataProvider.instance.GetLastSets(p2id, "2")
-            else:
-                StateManager.Set(f"score.last_sets.2", {})
-    
-    def UpdateLastSets(self, data):
-        StateManager.BlockSaving()
-        i = 1
-        for set in data.get("last_sets", []):
-            StateManager.Set(f"score.last_sets." + data.get("playerNumber") + "." + str(i), {
-                "phase_id": set.get("phase_id"),
-                "phase_name": set.get("phase_name"),
-                "round_name": set.get("round_name"),
-                "player_score": set.get("player1_score"),
-                "player_team": set.get("player1_team"),
-                "player_name": set.get("player1_name"),
-                "oponent_score": set.get("player2_score"),
-                "oponent_team": set.get("player2_team"),
-                "oponent_name": set.get("player2_name")
-            })
-            i+=1
-        StateManager.ReleaseSaving()
-    
-    def GetPlayerHistoryStandingsP1(self):
-        # Only if 1 player on each side
-        if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
-            p1id = StateManager.Get(f"score.team.1.player.1.id")
-            if p1id:
-                TSHTournamentDataProvider.instance.GetPlayerHistoryStandings(p1id, "1", StateManager.Get(f"game.smashgg_id"))
-            else:
-                StateManager.Set(f"score.history_sets.1", {})
-    
-    def GetPlayerHistoryStandingsP2(self):
-        # Only if 1 player on each side
-        if len(self.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
-            p2id = StateManager.Get(f"score.team.2.player.1.id")
-            if p2id:
-                TSHTournamentDataProvider.instance.GetPlayerHistoryStandings(p2id, "2", StateManager.Get(f"game.smashgg_id"))
-            else:
-                StateManager.Set(f"score.history_sets.2", {})
-    
-    def UpdateHistorySets(self, data):
-        StateManager.BlockSaving()
-        i = 1
-        for set in data.get("history_sets", []):
-            StateManager.Set(f"score.history_sets." + data.get("playerNumber") + "." + str(i), {
-                "placement": set.get("placement"),
-                "event_name": set.get("event_name"),
-                "tournament_name": set.get("tournament_name"),
-                "tournament_picture": set.get("tournament_picture"),
-                "entrants": set.get("entrants")
-            })
-            i+=1
         StateManager.ReleaseSaving()
 
     def ResetScore(self):

--- a/src/TSHStatsUtil.py
+++ b/src/TSHStatsUtil.py
@@ -1,0 +1,161 @@
+from PyQt5.QtCore import *
+
+from datetime import datetime
+import math
+
+from .StateManager import *
+from .TSHTournamentDataProvider import TSHTournamentDataProvider
+
+class TSHStatsSignals(QObject):
+    RecentSetsSignal = pyqtSignal()
+    LastSetsP1Signal = pyqtSignal()
+    LastSetsP2Signal = pyqtSignal()
+    PlayerHistoryStandingsP1Signal = pyqtSignal()
+    PlayerHistoryStandingsP2Signal = pyqtSignal()
+
+class TSHStatsUtil:
+    instance: "TSHStatsUtil" = None
+
+    def __init__(self):
+        self.signals: TSHStatsSignals = TSHStatsSignals()
+
+        self.signals.PlayerHistoryStandingsP1Signal.connect(self.GetPlayerHistoryStandingsP1)
+        self.signals.PlayerHistoryStandingsP2Signal.connect(self.GetPlayerHistoryStandingsP2)
+        self.signals.LastSetsP1Signal.connect(self.GetLastSetsP1)
+        self.signals.LastSetsP2Signal.connect(self.GetLastSetsP2)
+        self.signals.RecentSetsSignal.connect(self.GetRecentSets)
+
+        TSHTournamentDataProvider.instance.signals.history_sets_updated.connect(
+            self.UpdateHistorySets)
+        TSHTournamentDataProvider.instance.signals.last_sets_updated.connect(
+            self.UpdateLastSets)
+        TSHTournamentDataProvider.instance.signals.recent_sets_updated.connect(
+            self.UpdateRecentSets)
+    
+    def GetRecentSets(self):
+        updated = False
+        # Only if 1 player on each side
+        if len(self.scoreboard.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
+            p1id = StateManager.Get(f"score.team.1.player.1.id")
+            p2id = StateManager.Get(f"score.team.2.player.1.id")
+            if p1id and p2id and json.dumps(p1id) != json.dumps(p2id):
+                StateManager.Set(f"score.recent_sets", {
+                    "state": "loading",
+                    "sets": []
+                })
+                TSHTournamentDataProvider.instance.GetRecentSets(p1id, p2id)
+                updated = True
+
+        if not updated:
+            StateManager.Set(f"score.recent_sets", {
+                "state": "done",
+                "sets": []
+            })
+
+    def UpdateRecentSets(self, data):
+        lastUpdateTime = StateManager.Get(f"score.recent_sets.request_time", 0)
+
+        if data.get("request_time", 0) > lastUpdateTime:
+            StateManager.Set(f"score.recent_sets", {
+                "state": "done",
+                "sets": data.get("sets"),
+                "request_time": data.get("request_time")
+            })
+    
+    def GetLastSetsP1(self):
+        # Only if 1 player on each side
+        if len(self.scoreboard.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance:
+            p1id = StateManager.Get(f"score.team.1.player.1.id")
+            if p1id:
+                TSHTournamentDataProvider.instance.GetLastSets(p1id, "1")
+            else:
+                StateManager.Set(f"score.last_sets.1", {})
+    
+    def GetLastSetsP2(self):
+        # Only if 1 player on each side
+        if len(self.scoreboard.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance:
+            p2id = StateManager.Get(f"score.team.2.player.1.id")
+            if p2id:
+                TSHTournamentDataProvider.instance.GetLastSets(p2id, "2")
+            else:
+                StateManager.Set(f"score.last_sets.2", {})
+    
+    def UpdateLastSets(self, data):
+        StateManager.BlockSaving()
+        i = 1
+        for set in data.get("last_sets", []):
+            StateManager.Set(f"score.last_sets." + data.get("playerNumber") + "." + str(i), {
+                "phase_id": set.get("phase_id"),
+                "phase_name": set.get("phase_name"),
+                "round_name": set.get("round_name"),
+                "player_score": set.get("player1_score"),
+                "player_team": set.get("player1_team"),
+                "player_name": set.get("player1_name"),
+                "oponent_score": set.get("player2_score"),
+                "oponent_team": set.get("player2_team"),
+                "oponent_name": set.get("player2_name")
+            })
+            i+=1
+        StateManager.ReleaseSaving()
+
+    def GetPlayerHistoryStandingsP1(self):
+        # Only if 1 player on each side
+        if len(self.scoreboard.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
+            p1id = StateManager.Get(f"score.team.1.player.1.id")
+            if p1id:
+                TSHTournamentDataProvider.instance.GetPlayerHistoryStandings(p1id, "1", StateManager.Get(f"game.smashgg_id"))
+            else:
+                StateManager.Set(f"score.history_sets.1", {})
+    
+    def GetPlayerHistoryStandingsP2(self):
+        # Only if 1 player on each side
+        if len(self.scoreboard.team1playerWidgets) == 1 and TSHTournamentDataProvider.instance and TSHTournamentDataProvider.instance.provider.name == "StartGG":
+            p2id = StateManager.Get(f"score.team.2.player.1.id")
+            if p2id:
+                TSHTournamentDataProvider.instance.GetPlayerHistoryStandings(p2id, "2", StateManager.Get(f"game.smashgg_id"))
+            else:
+                StateManager.Set(f"score.history_sets.2", {})
+
+    def UpdateHistorySets(self, data):
+        StateManager.BlockSaving()
+        i = 1
+        for set in data.get("history_sets", []):
+            StateManager.Set(f"score.history_sets." + data.get("playerNumber") + "." + str(i), {
+                "placement": set.get("placement"),
+                "event_name": set.get("event_name"),
+                "tournament_name": set.get("tournament_name"),
+                "tournament_picture": set.get("tournament_picture"),
+                "entrants": set.get("entrants"),
+                "event_date_month": datetime.fromtimestamp(set.get("event_date")).strftime("%B"),
+                "event_date_day": datetime.fromtimestamp(set.get("event_date")).strftime("%d"),
+                "event_date_year": datetime.fromtimestamp(set.get("event_date")).strftime("%Y")
+            })
+            i+=1
+        StateManager.ReleaseSaving()
+    
+    # Calculation of Seeding/Placement to determine
+    # Upset Factor or Seeding Performance Rating
+    #
+    # bracket_type [INTEGER] = The bracket type returned from Start.GG
+    # or from Challonge
+    # Double Elim = 1, Single Elim = 2 (Could be wrong, will need to test)
+    #
+    # x [INTEGER] = The seeding/placement value being used to determine
+    # the end product (Ex. Seeding for UF or Seeding/Placement for SPR)
+    def CalculatePlacementMath(self, bracket_type, x):
+        # Due to how the logs works, if the player is first seed,
+        # the value will always be 0 and no math needs to be done.
+        if x == 1:
+            return 0
+        
+        single_elim_calc = math.floor(math.log2(x - 1))
+        double_elim_calc = math.ceil(math.log2((2 * x) / 3))
+
+        # Double Elimination Sum of Values
+        if bracket_type == 1:
+            return single_elim_calc + double_elim_calc
+        # Single Elimination Sum of Values
+        elif bracket_type == 2:
+            return single_elim_calc
+    
+TSHStatsUtil.instance = TSHStatsUtil()

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -6,6 +6,7 @@ from flask import Flask, send_from_directory, request
 from flask_cors import CORS, cross_origin
 import json
 from .StateManager import StateManager
+from .TSHStatsUtil import TSHStatsUtil
 
 
 class WebServer(QThread):
@@ -212,6 +213,40 @@ class WebServer(QThread):
     @app.route('/pull-user')
     def pull_user_set():
         WebServer.scoreboard.signals.UserSetSelection.emit()
+        return "OK"
+
+    # Resubmits Call for Recent Sets
+    @app.route('/stats-recent-sets')
+    def stats_recent_sets():
+        TSHStatsUtil.instance.signals.RecentSetsSignal.emit()
+        return "OK"
+
+    # Resubmits Call for Last Sets
+    @app.route('/stats-last-sets-<player>')
+    def stats_last_sets(player):
+        if player == "1":
+            TSHStatsUtil.instance.signals.LastSetsP1Signal.emit()
+        elif player == "2":
+            TSHStatsUtil.instance.signals.LastSetsP2Signal.emit()
+        elif player == "both":
+            TSHStatsUtil.instance.signals.LastSetsP1Signal.emit()
+            TSHStatsUtil.instance.signals.LastSetsP2Signal.emit()
+        else:
+            print("[Last Sets] Unable to find player defined. Allowed values are: 1, 2, or both")
+        return "OK"
+
+   # Resubmits Call for History Sets
+    @app.route('/stats-history-sets-<player>')
+    def stats_history_sets(player):
+        if player == "1":
+            TSHStatsUtil.instance.signals.PlayerHistoryStandingsP1Signal.emit()
+        elif player == "2":
+            TSHStatsUtil.instance.signals.PlayerHistoryStandingsP2Signal.emit()
+        elif player == "both":
+            TSHStatsUtil.instance.signals.PlayerHistoryStandingsP1Signal.emit()
+            TSHStatsUtil.instance.signals.PlayerHistoryStandingsP2Signal.emit()
+        else:
+            print("[History Standings] Unable to find player defined. Allowed values are: 1, 2, or both")
         return "OK"
 
     # Resets scores

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -833,14 +833,14 @@ class StartGGDataProvider(TournamentDataProvider):
                     "event_name": event.get("name"),
                     "tournament_name": tournament.get("name"),
                     "tournament_picture": tournamentPicture,
-                    "entrants": event.get("numEntrants")
+                    "entrants": event.get("numEntrants"),
+                    "event_date": event.get("startAt")
                 }
 
                 set_data.append(player_history)
 
             callback.emit({"playerNumber": playerNumber, "history_sets": set_data})
         except Exception as e:
-            traceback.print_exc()
             callback.emit({"playerNumber": playerNumber,"history_sets": []})
 
     def GetRecentSets(self, id1, id2, callback, requestTime, progress_callback):
@@ -1143,6 +1143,11 @@ class StartGGDataProvider(TournamentDataProvider):
                     }
                 else:
                     playerData["mains"] = {}
+        if "id" not in playerData:
+            playerData["id"] = [
+                player.get("id"),
+                0
+            ]
 
         return(playerData)
 

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -335,6 +335,9 @@ class StartGGDataProvider(TournamentDataProvider):
                         player.get("id"),
                         0
                     ]
+                if deep_get(_set, "slots", [])[i].get("entrant", {}).get("seeds", []) != []:
+                    playerData["seed"] = deep_get(_set, "slots", [])[i].get(
+                    "entrant", {}).get("seeds", [])[0].get("seedNum", 0)
                 players[i].append(playerData)
 
         setData["entrants"] = players
@@ -1030,6 +1033,8 @@ class StartGGDataProvider(TournamentDataProvider):
                 for i, team in enumerate(entrants):
                     for j, entrant in enumerate(team.get("participants", [])):
                         playerData = StartGGDataProvider.ProcessEntrantData(entrant)
+                        if deep_get(team, "seeds", []) != []:
+                            playerData["seed"] = deep_get(team, "seeds", [])[0].get("seedNum", 0)
                         players.append(playerData)
 
                 TSHPlayerDB.AddPlayers(players)

--- a/src/TournamentDataProvider/StartGGEntrantsQuery.txt
+++ b/src/TournamentDataProvider/StartGGEntrantsQuery.txt
@@ -16,6 +16,9 @@ query EventEntrantsListQuery($eventSlug: String!, $videogameId: Int, $page: Int!
       nodes {
         id
         name
+        seeds {
+          seedNum
+        }
         participants {
           player {
             id

--- a/src/TournamentDataProvider/StartGGPlayerTournamentHistoryQuery.txt
+++ b/src/TournamentDataProvider/StartGGPlayerTournamentHistoryQuery.txt
@@ -6,6 +6,7 @@ query TournamentHistoryDataQuery($playerID: ID!, $gameID: ID!) {
         event {
           name
           numEntrants
+          startAt
           tournament {
             name
             images(type: "profile") {

--- a/src/TournamentDataProvider/StartGGSetQuery.txt
+++ b/src/TournamentDataProvider/StartGGSetQuery.txt
@@ -15,6 +15,9 @@ query SetQuery($id: ID!) {
             entrant {
                 id
                 name
+                seeds {
+                    seedNum
+                }
                 participants {
                     id
                     user {


### PR DESCRIPTION
- Shifted existing stats to new utility class for easier expansion and additions.
- Added Start Date to History Standings for a little more info of when it completed.
	- Will need to add to current overlay.
	- Potentially adding it as a faded background object on the layout would work for it. (Like the sponsor logo on the Top 8 layout)
- Added ability to recall stats via TSHWebServer for potential live updating down the line.
	- This is more if the data is slightly out of date. (Ex. new set was completed that we can pull)
- Started base for Upset Factor and Seeding Performance Rating addition.
- Added additional bug fix as sometimes the Player ID was still not getting exported, it should now _hopefully_ be fixed.