### PR TITLE
Feature/top8 date

### DIFF
--- a/src/TSHTournamentInfoWidget.py
+++ b/src/TSHTournamentInfoWidget.py
@@ -20,14 +20,12 @@ class TSHTournamentInfoWidget(QDockWidget):
         TSHTournamentDataProvider.instance.signals.tournament_data_updated.connect(
             self.UpdateData)
 
-# TODO value (QDate) -> String ?
         for widget in self.findChildren(QDateEdit):
-            print("-----")
-            print(widget.objectName())
             widget.dateChanged.connect(lambda value, element=widget: [
                 StateManager.Set(
-                    f"tournamentInfo.{element.objectName()}", value)
+                    f"tournamentInfo.{element.objectName()}", value.toString('dd/MM/yyyy'))
             ])
+            #widget.setDate(d)
             #widget.setValue(StateManager.Get(
             #    f"tournamentInfo.{widget.objectName()}", 0))
 

--- a/src/TSHTournamentInfoWidget.py
+++ b/src/TSHTournamentInfoWidget.py
@@ -3,6 +3,7 @@ from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
 from PyQt5 import uic
 import json
+import time
 from .Helpers.TSHCountryHelper import TSHCountryHelper
 from .StateManager import StateManager
 from .TSHGameAssetManager import TSHGameAssetManager
@@ -18,6 +19,17 @@ class TSHTournamentInfoWidget(QDockWidget):
 
         TSHTournamentDataProvider.instance.signals.tournament_data_updated.connect(
             self.UpdateData)
+
+# TODO value (QDate) -> String ?
+        for widget in self.findChildren(QDateEdit):
+            print("-----")
+            print(widget.objectName())
+            widget.dateChanged.connect(lambda value, element=widget: [
+                StateManager.Set(
+                    f"tournamentInfo.{element.objectName()}", value)
+            ])
+            #widget.setValue(StateManager.Get(
+            #    f"tournamentInfo.{widget.objectName()}", 0))
 
         for widget in self.findChildren(QLineEdit):
             if widget.objectName() != "qt_spinbox_lineedit":
@@ -58,3 +70,15 @@ class TSHTournamentInfoWidget(QDockWidget):
 
                 if type(widget) == QSpinBox:
                     widget.setValue(data[key])
+
+                if type(widget) == QDateEdit:
+                    # This is how to put a date into QDateEdit Element using a timestamp
+                    #        aTime = '2018-07-24 19:24:11.272000'
+                    unix_timestamp = float(data[key])
+                    #        tmToDate = datetime.datetime.utcfromtimestamp(unix_timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                    #        utc_time = time.gmtime(unix_timestamp)
+                    local_datetime = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(
+                        unix_timestamp))  # converts timestampt to local time and apply the format
+                    local_date = local_datetime.split(" ")[0]  # get only the date
+                    d = QDate.fromString(local_date, "yyyy-MM-dd")  # Convert date into QDate object
+                    widget.setDate(d)

--- a/src/TournamentDataProvider/ChallongeDataProvider.py
+++ b/src/TournamentDataProvider/ChallongeDataProvider.py
@@ -3,6 +3,8 @@ import os
 import traceback
 import re
 import json
+from datetime import datetime
+from dateutil.parser import parse
 from ..Helpers.TSHDictHelper import deep_get
 from ..TSHGameAssetManager import TSHGameAssetManager
 from ..TSHPlayerDB import TSHPlayerDB
@@ -37,8 +39,8 @@ class ChallongeDataProvider(TournamentDataProvider):
                 )
 
                 data = json.loads(data.text)
-
                 collection = deep_get(data, "collection", [{}])[0]
+                details = deep_get(collection, "details", [])
 
                 videogame = collection.get("filter", {}).get("id", None)
                 if videogame:
@@ -47,6 +49,21 @@ class ChallongeDataProvider(TournamentDataProvider):
                     self.videogame = videogame
 
                 finalData["tournamentName"] = deep_get(collection, "name")
+
+                # TODO necessary ?
+                if len(details) > 3:
+                    startAtStr = deep_get(details[2], "text", "")
+                    try:
+                        # test if date
+                        parse(startAtStr, fuzzy=False)
+                        # 'September 29, 2022'
+                        element = datetime.strptime(startAtStr, "%B %d, %Y")
+                        # to timestamp
+                        timestamp = datetime.timestamp(element)
+                        print('date', element, 'stamp', timestamp)
+                        finalData["startAt"] = datetime.timestamp(element)
+                    except ValueError:
+                        print(' - no date defined')
 
                 details = collection.get("details", [])
                 participantsElement = next(

--- a/src/TournamentDataProvider/ChallongeDataProvider.py
+++ b/src/TournamentDataProvider/ChallongeDataProvider.py
@@ -60,7 +60,6 @@ class ChallongeDataProvider(TournamentDataProvider):
                         element = datetime.strptime(startAtStr, "%B %d, %Y")
                         # to timestamp
                         timestamp = datetime.timestamp(element)
-                        print('date', element, 'stamp', timestamp)
                         finalData["startAt"] = datetime.timestamp(element)
                     except ValueError:
                         print(' - no date defined')

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -72,6 +72,8 @@ class StartGGDataProvider(TournamentDataProvider):
                 data, "data.event.tournament.venueAddress", "")
             finalData["shortLink"] = deep_get(
                 data, "data.event.tournament.shortSlug", "")
+            finalData["startAt"] = deep_get(
+                data, "data.event.tournament.startAt", "")
         except:
             traceback.print_exc()
 

--- a/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
@@ -12,6 +12,8 @@ query TournamentDataQuery($eventSlug: String!) {
         name
         shortSlug
         venueAddress
+        startAt
+        endAt
     }
   }
 }

--- a/src/layout/TSHTournamentInfo.ui
+++ b/src/layout/TSHTournamentInfo.ui
@@ -95,6 +95,16 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="1">
+       <widget class="QDateEdit" name="startAt"/>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Date</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>


### PR DESCRIPTION
This PR add a new information for the tournamenet : the date 'startAt' (start of tournament)
![image](https://user-images.githubusercontent.com/9060357/203431791-8a36bc4c-0617-4517-822c-32d5a5252f9b.png)

I may put an example in the future, in the same style as all example, like a top_8 with a top bar with informations : 
![image](https://user-images.githubusercontent.com/9060357/203431269-9b6f08db-73cf-441c-bfad-813807c8268d.png)

If you see anything that missing or what, tell me !