### PR TITLE
Use Current Locale Date Format

### DIFF
--- a/src/TSHTournamentInfoWidget.py
+++ b/src/TSHTournamentInfoWidget.py
@@ -25,7 +25,7 @@ class TSHTournamentInfoWidget(QDockWidget):
         for widget in self.findChildren(QDateEdit):
             widget.dateChanged.connect(lambda value, element=widget: [
                 StateManager.Set(
-                    f"tournamentInfo.{element.objectName()}", value.toString('dd/MM/yyyy'))
+                    f"tournamentInfo.{element.objectName()}", value.toString(Qt.DateFormat.LocaleDate))
             ])
             # widget.setDate(d)
             # widget.setValue(StateManager.Get(


### PR DESCRIPTION
This addresses #320 to match current locale date formatting. This will obviously need more testing and I think relies more on current OS locale, but is definitely less of a headache than other ways I looked into