### PR TITLE
Fixes Tedious Error on Build

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - run: |
@@ -73,7 +73,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - run: pip install -r dependencies/requirements.txt pyinstaller==4.10


### PR DESCRIPTION
GitHub has been putting slightly tedious messages to update workflows that used the set-output variables to a new method as they are sunsetting that way by the end of May. This adjusts the 2 places we use it to use the new method.

This was tested on one of my other forks and appears to be working as intended.