### PR TITLE
Fixes Player Seeds not swapping when switching teams

### DIFF
--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -277,6 +277,8 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                 f"{w.path}.online_avatar")
             data["id"] = StateManager.Get(
                 f"{w.path}.id")
+            data["seed"] = StateManager.Get(
+                f"{w.path}.seed")
             tmpData.append(data)
 
         # Load state
@@ -292,6 +294,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             QCoreApplication.processEvents()
             w.ExportPlayerImages(tmpData[i]["online_avatar"])
             w.ExportPlayerId(tmpData[i]["id"])
+            StateManager.Set(f"{w.path}.seed", tmpData[i]["seed"])
 
     def SetIndex(self, index: int, team: int):
         self.findChild(QWidget, "title").setText(

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -561,6 +561,8 @@ class TSHScoreboardWidget(QDockWidget):
                     f"score.team.{t+1}.player.{i+1}.online_avatar")
                 data["id"] = StateManager.Get(
                     f"score.team.{t+1}.player.{i+1}.id")
+                data["seed"] = StateManager.Get(
+                    f"score.team.{t+1}.player.{i+1}.seed")
                 tmpData[t].append(data)
 
         # Load state
@@ -577,6 +579,8 @@ class TSHScoreboardWidget(QDockWidget):
                 QCoreApplication.processEvents()
                 team[i].ExportPlayerImages(tmpData[t][i]["online_avatar"])
                 team[i].ExportPlayerId(tmpData[t][i]["id"])
+                StateManager.Set(
+                    f"score.team.{len(tmpData[t])-t+1}.player.{i+1}.seed", tmpData[t][i]["seed"])
 
         # Scores
         scoreLeft = self.scoreColumn.findChild(QSpinBox, "score_left").value()


### PR DESCRIPTION
This addresses a flaw that was found where swapping player positions and teams would cause the seed variable to not swap as expected. This was tested by shifting players up and down on their own team, and swapping teams to make seeds do properly cross to the other team.