### PR TITLE
Fixes a crash when swapping players

### DIFF
--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -181,7 +181,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             if color.currentData() and color.currentData().get("en_name", ""):
                 data["en_name"] = color.currentData().get("en_name", "")
 
-            if character.currentData():
+            if color.currentData() and character.currentData():
                 data["assets"] = color.currentData().get("assets", {})
 
             if data.get("assets") == None:


### PR DESCRIPTION
Currently there appears to be an issue that happens when teams are swapped with players that have character data assigned, which causes TSH to outright crash. I am not sure if this is the approach that we want to use to fix it, but at least in my testing, this does appear to not cause the crash any more.

Note: The crash can be averted with character amounts set to 0 for the time being