### PR TITLE
Minor positioning fixes for mainstagy

### DIFF
--- a/layout/scoreboard_mainstagy/index.css
+++ b/layout/scoreboard_mainstagy/index.css
@@ -177,28 +177,26 @@ body {
 }
 
 .sponsor_container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  position: absolute;
+  width: 118px;
+  height: 118px;
+}
+
+.p1 .sponsor_container {
+  right: 0px;
+}
+
+.p2 .sponsor_container {
+  left: 0px;
 }
 
 .sponsor_logo {
   opacity: 0.15;
-  position: absolute;
-  display: inline-block;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
   width: 118px;
   height: 118px;
-}
-
-.p1 .sponsor_logo {
-  right: -40px;
-}
-
-.p2 .sponsor_logo {
-  left: -40px;
 }
 
 .flags_container {
@@ -236,7 +234,7 @@ body {
   text-align: center;
   justify-content: center;
   box-sizing: border-box;
-  background: rgba(255, 255, 255, 1);
+  background: white;
   top: 26px;
 }
 
@@ -263,8 +261,8 @@ body {
   position: absolute;
   width: 320px;
   height: 110px;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
+  border-bottom-left-radius: 15px;
+  border-bottom-right-radius: 15px;
   background: linear-gradient(
     90deg,
     rgba(54, 46, 99, 0.95) 0%,
@@ -283,7 +281,7 @@ body {
 
 .losers_container {
   position: absolute;
-  width: 50px;
+  width: 70px;
   height: 42px;
   background: white;
   top: 5px;

--- a/layout/scoreboard_mainstagy/index.js
+++ b/layout/scoreboard_mainstagy/index.js
@@ -11,7 +11,7 @@ LoadEverything().then(() => {
 
   const EASE_ANIMATION = "power2.Out";
 
-  const LOSERS_CONTAINER_TRAVEL = "270px";
+  const LOSERS_CONTAINER_TRAVEL = "295px";
 
   let startingAnimation = gsap
     .timeline({ paused: true })


### PR DESCRIPTION
Updated so that the big sponsor logo is now properly centered behind the small sponsor logo. Also changed the border radius of logo container, dimension of losers containers, and travel distance of losers containers.