### PR TITLE
Fix sets being mixed up because of async calls

### DIFF
--- a/layout/settings.json
+++ b/layout/settings.json
@@ -1,6 +1,7 @@
 {
   "assets": {
-    "default": {
+    "default": {},
+    "ssbu": {
       "asset_key": "website"
     },
     "game_codename_example": {

--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -33,7 +33,7 @@ class StateManager:
                 StateManager.threads = []
 
                 def ExportAll():
-                    with open("./out/program_state.json", 'w', encoding='utf-8') as file:
+                    with open("./out/program_state.json", 'w', encoding='utf-8', buffering=8192) as file:
                         # print("SaveState")
                         json.dump(StateManager.state, file, indent=4, sort_keys=False)
 

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -732,6 +732,11 @@ class TSHScoreboardWidget(QDockWidget):
         self.team2column.findChild(QCheckBox, "losers").setChecked(False)
 
     def UpdateSetData(self, data):
+        # If you switched sets and it was still finishing an async update call
+        # Avoid loading data from the previous set
+        if data.get("id") != self.lastSetSelected:
+            return
+        
         StateManager.BlockSaving()
 
         if data.get("round_name"):


### PR DESCRIPTION
When changing sets, not too rarely:
- async call for set 1 is started
- set is changed to set 2
- set 2 data comes in
- set 1 data finishes processing and comes in
- current set data becomes a mix of set 1 and 2, mostly with set 1 things because it overwrites set 2 things on set id change