### PR TITLE
Spaced name, sponsor, and losers evenly + improved Twitter/Pronouns and Match/Best of switching logic

### DIFF
--- a/layout/scoreboard_vgbootcampy_classic/index.css
+++ b/layout/scoreboard_vgbootcampy_classic/index.css
@@ -95,7 +95,6 @@ body {
   justify-content: center;
   box-sizing: border-box;
   overflow: hidden;
-  padding: 0 12px;
 }
 
 .p1 .inner_container {
@@ -105,6 +104,7 @@ body {
     var(--p1-sponsor-color) 0%,
     var(--bg-color) 40%
   );
+  padding-right: 12px;
 }
 
 .p2 .inner_container {
@@ -114,6 +114,7 @@ body {
     var(--p2-sponsor-color) 0%,
     var(--bg-color) 40%
   );
+  padding-left: 12px;
 }
 
 .name {
@@ -127,6 +128,7 @@ body {
   flex-direction: column;
   overflow: hidden;
   color: var(--text-color);
+  word-spacing: 2px;
 }
 
 .p1 .name {
@@ -244,6 +246,14 @@ body {
   height: 31px;
 }
 
+.p1 .flag {
+  margin-left: 12px;
+}
+
+.p2 .flag {
+  margin-right: 12px;
+}
+
 .score {
   position: absolute;
   display: flex;
@@ -270,10 +280,6 @@ body {
   right: 827px;
   color: var(--p2-score-color);
   background: var(--p2-score-bg-color);
-}
-
-.sponsor {
-  margin-right: 10px;
 }
 
 .p1 .sponsor {

--- a/layout/scoreboard_vgbootcampy_classic/index.js
+++ b/layout/scoreboard_vgbootcampy_classic/index.js
@@ -11,6 +11,9 @@ LoadEverything().then(() => {
   let newP2Pronoun = "";
   let savedBestOf = 0;
   let savedMatch = "";
+  let firstTime = true;
+
+  let intervalID = "";
 
   let startingAnimation = gsap
     .timeline({ paused: true })
@@ -59,8 +62,7 @@ LoadEverything().then(() => {
 
   Start = async () => {
     startingAnimation.restart();
-    matchIntervalID = setInterval(UpdateMatch, 9000);
-    twitterIntervalID = setInterval(UpdateTwitter, 9000);
+    intervalID = setInterval(UpdateTwitterMatch, 9000);
     setInterval(TwitterPronounChecker, 100);
     setInterval(matchChecker, 100);
   };
@@ -110,8 +112,14 @@ LoadEverything().then(() => {
     if (Object.keys(oldData).length == 0) {
       UpdateMatch();
       UpdateTwitter();
+      firstTime = false;
     }
   };
+
+  async function UpdateTwitterMatch() {
+    UpdateTwitter();
+    UpdateMatch();
+  }
 
   async function UpdateMatch() {
     const tournamentContainer = document.querySelector(".tournament_container");
@@ -249,28 +257,25 @@ LoadEverything().then(() => {
           t == 0 &&
           !(p1Twitter == player.twitter && p1Pronoun == player.pronoun)
         ) {
-          clearIntervals();
           refreshNeeded = true;
         } else if (
           t == 1 &&
           !(p2Twitter == player.twitter && p2Pronoun == player.pronoun)
         ) {
-          clearIntervals();
           refreshNeeded = true;
         }
       });
     });
-    if (refreshNeeded) {
+    if (refreshNeeded && !firstTime) {
       UpdateTwitter();
-      twitterIntervalID = setInterval(UpdateTwitter, 9000);
-      matchIntervalID = setInterval(UpdateMatch, 9000);
+      resetIntervals();
     }
     refreshNeeded = false;
+  }
 
-    function clearIntervals() {
-      clearInterval(twitterIntervalID);
-      clearInterval(matchIntervalID);
-    }
+  function resetIntervals() {
+    clearInterval(intervalID);
+    intervalID = setInterval(UpdateTwitterMatch, 9000);
   }
 
   async function matchChecker() {
@@ -279,19 +284,13 @@ LoadEverything().then(() => {
     if (
       !(savedBestOf == data.score.best_of && savedMatch == data.score.match)
     ) {
-      clearIntervals();
       refreshNeeded = true;
     }
 
-    if (refreshNeeded) {
+    if (refreshNeeded && !firstTime) {
       UpdateMatch();
-      twitterIntervalID = setInterval(UpdateTwitter, 9000);
-      matchIntervalID = setInterval(UpdateMatch, 9000);
+      resetIntervals();
     }
     refreshNeeded = false;
-  }
-  function clearIntervals() {
-    clearInterval(twitterIntervalID);
-    clearInterval(matchIntervalID);
   }
 });

--- a/layout/scoreboard_vgbootcampy_classic/index.js
+++ b/layout/scoreboard_vgbootcampy_classic/index.js
@@ -78,11 +78,13 @@ LoadEverything().then(() => {
           SetInnerHtml(
             $(`.p${t + 1}.container .name`),
             `
+            <span>
               <span class="sponsor">
                 ${player.team ? player.team.toUpperCase() : ""}
               </span>
               ${player.name ? await Transcript(player.name.toUpperCase()) : ""}
               ${team.losers ? "(L)" : ""}
+            </span>
             `
           );
 

--- a/layout/scoreboard_vgbootcampy_neo/index.css
+++ b/layout/scoreboard_vgbootcampy_neo/index.css
@@ -119,6 +119,15 @@ body {
   flex-direction: column;
   overflow: hidden;
   color: var(--text-color);
+  word-spacing: 2px;
+}
+
+.p1 .name {
+  margin-left: 12px;
+}
+
+.p2 .name {
+  margin-right: 12px;
 }
 
 .twitter {
@@ -227,7 +236,14 @@ body {
   background-position: center;
   width: 44px;
   height: 31px;
-  margin: 0 12px;
+}
+
+.p1 .flag {
+  margin-left: 12px;
+}
+
+.p2 .flag {
+  margin-right: 12px;
 }
 
 .score {
@@ -250,10 +266,6 @@ body {
   margin-right: 12px;
   color: var(--p2-score-color);
   background: var(--p2-score-bg-color);
-}
-
-.sponsor {
-  margin-right: 10px;
 }
 
 .p1 .sponsor {

--- a/layout/scoreboard_vgbootcampy_neo/index.js
+++ b/layout/scoreboard_vgbootcampy_neo/index.js
@@ -11,6 +11,9 @@ LoadEverything().then(() => {
   let newP2Pronoun = "";
   let savedBestOf = 0;
   let savedMatch = "";
+  let firstTime = true;
+
+  let intervalID = "";
 
   let startingAnimation = gsap
     .timeline({ paused: true })
@@ -59,8 +62,7 @@ LoadEverything().then(() => {
 
   Start = async () => {
     startingAnimation.restart();
-    matchIntervalID = setInterval(UpdateMatch, 9000);
-    twitterIntervalID = setInterval(UpdateTwitter, 9000);
+    intervalID = setInterval(UpdateTwitterMatch, 9000);
     setInterval(TwitterPronounChecker, 100);
     setInterval(matchChecker, 100);
   };
@@ -110,8 +112,14 @@ LoadEverything().then(() => {
     if (Object.keys(oldData).length == 0) {
       UpdateMatch();
       UpdateTwitter();
+      firstTime = false;
     }
   };
+
+  async function UpdateTwitterMatch() {
+    UpdateTwitter();
+    UpdateMatch();
+  }
 
   async function UpdateMatch() {
     const tournamentContainer = document.querySelector(".tournament_container");
@@ -249,28 +257,25 @@ LoadEverything().then(() => {
           t == 0 &&
           !(p1Twitter == player.twitter && p1Pronoun == player.pronoun)
         ) {
-          clearIntervals();
           refreshNeeded = true;
         } else if (
           t == 1 &&
           !(p2Twitter == player.twitter && p2Pronoun == player.pronoun)
         ) {
-          clearIntervals();
           refreshNeeded = true;
         }
       });
     });
-    if (refreshNeeded) {
+    if (refreshNeeded && !firstTime) {
       UpdateTwitter();
-      twitterIntervalID = setInterval(UpdateTwitter, 9000);
-      matchIntervalID = setInterval(UpdateMatch, 9000);
+      resetIntervals();
     }
     refreshNeeded = false;
+  }
 
-    function clearIntervals() {
-      clearInterval(twitterIntervalID);
-      clearInterval(matchIntervalID);
-    }
+  function resetIntervals() {
+    clearInterval(intervalID);
+    intervalID = setInterval(UpdateTwitterMatch, 9000);
   }
 
   async function matchChecker() {
@@ -279,19 +284,13 @@ LoadEverything().then(() => {
     if (
       !(savedBestOf == data.score.best_of && savedMatch == data.score.match)
     ) {
-      clearIntervals();
       refreshNeeded = true;
     }
 
-    if (refreshNeeded) {
+    if (refreshNeeded && !firstTime) {
       UpdateMatch();
-      twitterIntervalID = setInterval(UpdateTwitter, 9000);
-      matchIntervalID = setInterval(UpdateMatch, 9000);
+      resetIntervals();
     }
     refreshNeeded = false;
-  }
-  function clearIntervals() {
-    clearInterval(twitterIntervalID);
-    clearInterval(matchIntervalID);
   }
 });

--- a/layout/scoreboard_vgbootcampy_neo/index.js
+++ b/layout/scoreboard_vgbootcampy_neo/index.js
@@ -78,11 +78,13 @@ LoadEverything().then(() => {
           SetInnerHtml(
             $(`.p${t + 1}.container .name`),
             `
+            <span>
               <span class="sponsor">
                 ${player.team ? player.team.toUpperCase() : ""}
               </span>
               ${player.name ? await Transcript(player.name.toUpperCase()) : ""}
               ${team.losers ? "(L)" : ""}
+            </span>
             `
           );
 


### PR DESCRIPTION
Hi, I made so that the name, sponsor, and losers have even spacings. I also cleaned up code for the Twitter/Pronouns and Match/Best of switching logic. Thanks!