### PR TITLE
allows thumbnail to be displayed without main logo per #267

### DIFF
--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -959,48 +959,49 @@ def paste_round_text(thumbnail, data, display_phase=True):
 
 
 def paste_main_icon(thumbnail, icon_path):
-    if icon_path:
-        max_x_size = round(
-            template_data["icons_position"]["main"]["dimensions"]["x"]*ratio[0])
-        max_y_size = round(
-            template_data["icons_position"]["main"]["dimensions"]["y"]*ratio[1])
-        max_size = (max_x_size, max_y_size)
+    max_x_size = round(
+        template_data["icons_position"]["main"]["dimensions"]["x"]*ratio[0])
+    max_y_size = round(
+        template_data["icons_position"]["main"]["dimensions"]["y"]*ratio[1])
+    max_size = (max_x_size, max_y_size)
 
-        icon_image = QPixmap(icon_path, 'RGBA')
-        icon_size = calculate_new_dimensions(icon_image.size(), max_size)
-        icon_image = icon_image.transformed(
-            QTransform().scale(
-                icon_size[0]/icon_image.width(), icon_size[1]/icon_image.height()),
-            Qt.TransformationMode.SmoothTransformation)
+    icon_image = QPixmap(icon_path, 'RGBA')
+    if icon_image.isNull():
+        return thumbnail
+    icon_size = calculate_new_dimensions(icon_image.size(), max_size)
+    icon_image = icon_image.transformed(
+        QTransform().scale(
+            icon_size[0]/icon_image.width(), icon_size[1]/icon_image.height()),
+        Qt.TransformationMode.SmoothTransformation)
 
-        x_offset = template_data["base_ratio"]["x"] / 2.0
+    x_offset = template_data["base_ratio"]["x"] / 2.0
+    if template_data["icons_position"]["bind_to_character_images"]:
+        x_offset = template_data["character_images"]["dimensions"]["x"] / \
+            2.0 + template_data["character_images"]["position"]["x"]
+
+    y_offset = template_data["icons_position"]["y_offset"]
+    if template_data["icons_position"]["bind_to_character_images"]:
+        y_offset = y_offset + \
+            template_data["character_images"]["position"]["y"]
+    if template_data["icons_position"]["align"].lower() == "bottom":
+        y_offset = template_data["base_ratio"]["y"] - \
+            template_data["icons_position"]["y_offset"] - \
+            icon_image.height()/ratio[1]
+        print(y_offset)
         if template_data["icons_position"]["bind_to_character_images"]:
-            x_offset = template_data["character_images"]["dimensions"]["x"] / \
-                2.0 + template_data["character_images"]["position"]["x"]
-
-        y_offset = template_data["icons_position"]["y_offset"]
-        if template_data["icons_position"]["bind_to_character_images"]:
-            y_offset = y_offset + \
-                template_data["character_images"]["position"]["y"]
-        if template_data["icons_position"]["align"].lower() == "bottom":
-            y_offset = template_data["base_ratio"]["y"] - \
+            y_offset = template_data["character_images"]["position"]["y"] + template_data["character_images"]["dimensions"]["y"] - \
                 template_data["icons_position"]["y_offset"] - \
                 icon_image.height()/ratio[1]
-            print(y_offset)
-            if template_data["icons_position"]["bind_to_character_images"]:
-                y_offset = template_data["character_images"]["position"]["y"] + template_data["character_images"]["dimensions"]["y"] - \
-                    template_data["icons_position"]["y_offset"] - \
-                    icon_image.height()/ratio[1]
 
-        icon_x = round(x_offset*ratio[0] - icon_size[0]/2)
-        icon_y = y_offset*ratio[1]
-        icon_coordinates = (icon_x, icon_y)
-        composite_image = create_composite_image(
-            icon_image, thumbnail.size(), icon_coordinates)
+    icon_x = round(x_offset*ratio[0] - icon_size[0]/2)
+    icon_y = y_offset*ratio[1]
+    icon_coordinates = (icon_x, icon_y)
+    composite_image = create_composite_image(
+        icon_image, thumbnail.size(), icon_coordinates)
 
-        painter = QPainter(thumbnail)
-        painter.drawPixmap(0, 0, composite_image)
-        painter.end()
+    painter = QPainter(thumbnail)
+    painter.drawPixmap(0, 0, composite_image)
+    painter.end()
     return(thumbnail)
 
 
@@ -1228,8 +1229,6 @@ def generate(settingsManager, isPreview=False, gameAssetManager=None):
     if not os.path.isfile(background_path):
         raise Exception(f"Background {background_path} doesn't exist !")
     main_icon_path = settings.get("main_icon_path", "")
-    if main_icon_path and not os.path.isfile(main_icon_path):
-        raise Exception(f"Main Icon {main_icon_path} doesn't exist !")
     side_icon_list = [
         deep_get(settings, f"side_icon_list.L", ""),
         deep_get(settings, f"side_icon_list.R", "")


### PR DESCRIPTION
If the main logo is not selected as a valid file (it points to a file that isn't there, there is no file, or it points to a non-image file), the thumbnail now displays without the logo