### PR TITLE
Fix StartGG API Break and fix weird asset crash potential

### DIFF
--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -22,8 +22,6 @@ class TSHGameAssetManagerSignals(QObject):
 class TSHGameAssetManager(QObject):
     instance: "TSHGameAssetManager" = None
 
-    gameLoaderThread = None
-
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.signals = TSHGameAssetManagerSignals()
@@ -127,29 +125,25 @@ class TSHGameAssetManager(QObject):
                 # print(self.parent().games)
                 self.parent().signals.onLoadAssets.emit()
 
-        self.gameLoaderThread = GameLoaderThread(self)
-        self.gameLoaderThread.start()
+        gameLoaderThread = GameLoaderThread(self)
+        gameLoaderThread.start()
 
     def SetGameFromStartGGId(self, gameid):
         if len(self.games.keys()) == 0:
             return
-        while(True):
-            if self.gameLoaderThread.isFinished():
-                for i, game in enumerate(self.games.values()):
-                    if str(game.get("smashgg_game_id")) == str(gameid):
-                        self.LoadGameAssets(i+1)
-                        break
+        
+        for i, game in enumerate(self.games.values()):
+            if str(game.get("smashgg_game_id")) == str(gameid):
+                self.LoadGameAssets(i+1)
                 break
 
     def SetGameFromChallongeId(self, gameid):
         if len(self.games.keys()) == 0:
             return
-        while(True):
-            if self.gameLoaderThread.isFinished():
-                for i, game in enumerate(self.games.values()):
-                    if str(game.get("challonge_game_id")) == str(gameid):
-                        self.LoadGameAssets(i+1)
-                        break
+        
+        for i, game in enumerate(self.games.values()):
+            if str(game.get("challonge_game_id")) == str(gameid):
+                self.LoadGameAssets(i+1)
                 break
 
     def LoadGameAssets(self, game: int = 0):

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -22,6 +22,8 @@ class TSHGameAssetManagerSignals(QObject):
 class TSHGameAssetManager(QObject):
     instance: "TSHGameAssetManager" = None
 
+    gameLoaderThread = None
+
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.signals = TSHGameAssetManagerSignals()
@@ -125,25 +127,29 @@ class TSHGameAssetManager(QObject):
                 # print(self.parent().games)
                 self.parent().signals.onLoadAssets.emit()
 
-        gameLoaderThread = GameLoaderThread(self)
-        gameLoaderThread.start()
+        self.gameLoaderThread = GameLoaderThread(self)
+        self.gameLoaderThread.start()
 
     def SetGameFromStartGGId(self, gameid):
         if len(self.games.keys()) == 0:
             return
-
-        for i, game in enumerate(self.games.values()):
-            if str(game.get("smashgg_game_id")) == str(gameid):
-                self.LoadGameAssets(i+1)
+        while(True):
+            if self.gameLoaderThread.isFinished():
+                for i, game in enumerate(self.games.values()):
+                    if str(game.get("smashgg_game_id")) == str(gameid):
+                        self.LoadGameAssets(i+1)
+                        break
                 break
 
     def SetGameFromChallongeId(self, gameid):
         if len(self.games.keys()) == 0:
             return
-
-        for i, game in enumerate(self.games.values()):
-            if str(game.get("challonge_game_id")) == str(gameid):
-                self.LoadGameAssets(i+1)
+        while(True):
+            if self.gameLoaderThread.isFinished():
+                for i, game in enumerate(self.games.values()):
+                    if str(game.get("challonge_game_id")) == str(gameid):
+                        self.LoadGameAssets(i+1)
+                        break
                 break
 
     def LoadGameAssets(self, game: int = 0):

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -550,9 +550,10 @@ class StartGGDataProvider(TournamentDataProvider):
                         playerData["startggMain"] = main[0][0]
 
                 if user:
-                    if len(user.get("authorizations", [])) > 0:
-                        playerData["twitter"] = user.get("authorizations", [])[
-                            0].get("externalUsername")
+                    if user.get("authorizations"):
+                        if len(user.get("authorizations", [])) > 0:
+                            playerData["twitter"] = user.get("authorizations", [])[
+                                0].get("externalUsername")
 
                     if user.get("genderPronoun"):
                         playerData["pronoun"] = user.get(
@@ -1356,9 +1357,10 @@ class StartGGDataProvider(TournamentDataProvider):
                 user.get("id")
             ]
 
-            if len(user.get("authorizations", [])) > 0:
-                playerData["twitter"] = user.get("authorizations", [])[
-                    0].get("externalUsername")
+            if user.get("authorizations"):
+                if len(user.get("authorizations", [])) > 0:
+                    playerData["twitter"] = user.get("authorizations", [])[
+                        0].get("externalUsername")
 
             if user.get("genderPronoun"):
                 playerData["pronoun"] = user.get(


### PR DESCRIPTION
This PR fixes the issue we've been seeing as of yesterday (May 6th) where StartGG started returning None for authorizations out of nowhere. There is also a fix in this PR for the asset manager as games like SFV would cause TSH to crash on loading due to no assets being found, so now when we go to load game assets by setting game from StartGG or Challonge, we will wait for the game loader thread to finish loading everything before we tell TSH to execute asset loading.