### PR TITLE
Edited README of vgbootcampy overlays to include overlay properties

### DIFF
--- a/layout/scoreboard_vgbootcampy/README.md
+++ b/layout/scoreboard_vgbootcampy/README.md
@@ -1,5 +1,5 @@
 # VGBC Style Overlay Properties:
-- Top left container displays the name of the tournament and the bottom containers display the players' Twitter handle.
+- The top left container displays the name of the tournament and the bottom containers display the players' Twitter handle.
 - The match is shown at the bottom of the left player container.
 - The phase and best of x is shown at the bottom of the right player container in "phase - best of x" format.
   - If only best of x is available, then only best of x is shown.

--- a/layout/scoreboard_vgbootcampy/README.md
+++ b/layout/scoreboard_vgbootcampy/README.md
@@ -1,9 +1,11 @@
-# VGBC Style Overlay:
-
-- Go to OBS and add a new Browser.
-- Select the /layout/scoreboard_vgbootcampy/index.html as the local file and set its width and height to 1920 and 1080 respectively.
-- Run TSH and enter the players' information.
-  - Select "Shutdown source when not visible" in the Browser's properties so that it plays the overlay animation every time it becomes visible.
+# VGBC Style Overlay Properties:
+- Top left container displays the name of the tournament and the bottom containers display the players' Twitter handle.
+- The match is shown at the bottom of the left player container.
+- The phase and best of x is shown at the bottom of the right player container in "phase - best of x" format.
+  - If only best of x is available, then only best of x is shown.
+  - If it is best of 0 and the phase is available, then only the phase is shown.
+- No information alternation takes place in this overlay. 
+- Select "Shutdown source when not visible" in the Browser's properties so that it plays the overlay animation every time it becomes visible.
 
 # Player Cams:
 

--- a/layout/scoreboard_vgbootcampy/README.md
+++ b/layout/scoreboard_vgbootcampy/README.md
@@ -1,5 +1,5 @@
 # VGBC Style Overlay Properties:
-- The top left container displays the name of the tournament and the bottom containers display the players' Twitter handle.
+- The top left container displays the name of the tournament and the bottom containers each display the player's Twitter handle.
 - The match is shown at the bottom of the left player container.
 - The phase and best of x is shown at the bottom of the right player container in "phase - best of x" format.
   - If only best of x is available, then only best of x is shown.

--- a/layout/scoreboard_vgbootcampy_classic/README.md
+++ b/layout/scoreboard_vgbootcampy_classic/README.md
@@ -1,11 +1,10 @@
-# Early 2022 VGBC Style Overlay:
-- Download the zip file and open it.
-- Move the scoreboard_vgbootcampy_classic file into the /layout folder of TSH where all the other scoreboard files are located.
-- Go to OBS and add a new Browser.
-- Select the /layout/scoreboard_vgbootcampy_classic/index.html as the local file and set its width and height to 1920 and 1080 respectively.
-- Run TSH and enter the players' information.
-  - Select "Shutdown source when not visible" in the Browser's properties so that it plays the overlay animation everytime it becomes visible.
-  
+# Early 2022 VGBC Style Overlay Properties:
+- The top left container alternates between match and best of x every 9 seconds. 
+- The bottom containers alternate between Twitter handle and pronouns every 9 seconds.
+- When one of the above information (match, best of x, Twitter handle, or pronouns) is edited, then the 9-second cycle is refreshed starting with match for the top left container and Twitter handle for the bottom containers.
+- For a container, if one of the information is missing, then the alternation does not happen. If both are missing, then the container disappears.
+- Select "Shutdown source when not visible" in the Browser's properties so the overlay animation is played everytime it becomes visible.
+
 # Player Cams:
 - Included in the scoreboard_vgbootcampy_classic file are the CameraWhiteBorders.png and CameraMask.png.
 - Add /layout/scoreboard_vgbootcampy_classic/CameraWhiteBorders.png as an Image in OBS to set the camera borders.

--- a/layout/scoreboard_vgbootcampy_neo/README.md
+++ b/layout/scoreboard_vgbootcampy_neo/README.md
@@ -1,10 +1,9 @@
-# Neo VGBC Style Overlay:
-- Download the zip file and open it.
-- Move the scoreboard_vgbootcampy_neo file into the /layout folder of TSH where all the other scoreboard files are located.
-- Go to OBS and add a new Browser.
-- Select the /layout/scoreboard_vgbootcampy_neo/index.html as the local file and set its width and height to 1920 and 1080 respectively.
-- Run TSH and enter the players' information.
-  - Select "Shutdown source when not visible" in the Browser's properties so that it plays the overlay animation everytime it becomes visible.
+# Neo VGBC Style Overlay Properties:
+- The top left container alternates between match and best of x every 9 seconds. 
+- The bottom containers alternate between Twitter handle and pronouns every 9 seconds.
+- When one of the above information (match, best of x, Twitter handle, or pronouns) is edited, then the 9-second cycle is refreshed starting with match for the top left container and Twitter handle for the bottom containers.
+- For a container, if one of the information is missing, then the alternation does not happen. If both are missing, then the container disappears.
+- Select "Shutdown source when not visible" in the Browser's properties so the overlay animation is played everytime it becomes visible.
   
 # Player Cams:
 - Included in the scoreboard_vgbootcampy_neo file are the CameraWhiteBorders.png and CameraMask.png.


### PR DESCRIPTION
Hello, I updated the READMEs of vgbootcampy, vgbootcampy_classic, and vgbootcampy_neo overlays to have explanations on how they work and what information they display. I deleted the part explaining how to download an overlay file since these files are already in the layout folder. Thank you!