### PR TITLE
Update build file with newer verisons of actions

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -7,6 +7,8 @@ on:
       - locale/*
       - feature/*
       - fix/*
+    paths-ignore:
+      - 'layout/**'
   workflow_dispatch:
 
 jobs:
@@ -19,8 +21,8 @@ jobs:
         os: ["ubuntu-20.04"]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
@@ -50,7 +52,7 @@ jobs:
           fi
 
       - name: push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.extract_branch.outputs.branch }}
@@ -67,8 +69,8 @@ jobs:
       - locale_build
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
@@ -95,7 +97,7 @@ jobs:
           git commit -m "Update exe" -a
 
       - name: push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
Updated currently used actions to more current versions of them to remove notices on running workflows about deprecation, as well as making the build system only run when a file outside the layout folder is committed to the repo.