### PR TITLE
Pull Seed on Entrant data, store it and push as needed

### DIFF
--- a/src/TSHStatsUtil.py
+++ b/src/TSHStatsUtil.py
@@ -167,8 +167,6 @@ class TSHStatsUtil:
         pass
 
     def UpdateStreamQueue(self, data):
-        print("=======================================UpdateStreamQueue==================================")
-        print(data)
         StateManager.BlockSaving()
 
         StateManager.Set(f"streamQueue", data)

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -609,8 +609,8 @@ class StartGGDataProvider(TournamentDataProvider):
                         player.get("id"),
                         0
                     ]
-                if deep_get(_set, "slots", [])[i].get("entrant", {}).get("seeds", []) != []:
-                    playerData["seed"] = self.player_seeds[playerData["id"][0]]
+                playerData["seed"] = self.player_seeds[playerData["id"][0]]
+                
                 players[i].append(playerData)
 
         setData["entrants"] = players

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -33,6 +33,8 @@ class StartGGDataProvider(TournamentDataProvider):
     TournamentPhaseGroupQuery = None
     StreamQueueQuery = None
 
+    player_seeds = {}
+
     def __init__(self, url, threadpool, parent) -> None:
         super().__init__(url, threadpool, parent)
         self.name = "StartGG"
@@ -608,8 +610,7 @@ class StartGGDataProvider(TournamentDataProvider):
                         0
                     ]
                 if deep_get(_set, "slots", [])[i].get("entrant", {}).get("seeds", []) != []:
-                    playerData["seed"] = deep_get(_set, "slots", [])[i].get(
-                    "entrant", {}).get("seeds", [])[0].get("seedNum", 0)
+                    playerData["seed"] = self.player_seeds[playerData["id"][0]]
                 players[i].append(playerData)
 
         setData["entrants"] = players
@@ -854,7 +855,6 @@ class StartGGDataProvider(TournamentDataProvider):
         })
 
     def GetStreamQueue(self, progress_callback=None):
-        print("========================================")
 
         try:
             data = requests.post(
@@ -1405,6 +1405,7 @@ class StartGGDataProvider(TournamentDataProvider):
                         playerData = StartGGDataProvider.ProcessEntrantData(entrant)
                         if deep_get(team, "seeds", []) != []:
                             playerData["seed"] = deep_get(team, "seeds", [])[0].get("seedNum", 0)
+                            self.player_seeds[playerData["id"][0]] = playerData["seed"]
                         players.append(playerData)
 
                 TSHPlayerDB.AddPlayers(players)

--- a/src/TournamentDataProvider/StartGGSetQuery.txt
+++ b/src/TournamentDataProvider/StartGGSetQuery.txt
@@ -15,9 +15,6 @@ query SetQuery($id: ID!) {
             entrant {
                 id
                 name
-                seeds {
-                    seedNum
-                }
                 participants {
                     id
                     user {


### PR DESCRIPTION
This should relieve an issue that was reported in the Discord server about the wrong seed being pulled when loading a set. Now instead of relying on what we pull from StartGG every time, we will now store the seeds in the StartGGDataProvider class on pulling entrant data and pull from that list/dictionary as the player gets pulled again based on the player ID.

This can probably be something we use to help roll it into making a proper player dictionary for storing their data to pull instead of StartGG every time as well.