### PR TITLE
Improve SF6 layouts

### DIFF
--- a/layout/scoreboard/index.css
+++ b/layout/scoreboard/index.css
@@ -27,6 +27,7 @@ body {
     drop-shadow(0 -1px 2px rgba(0, 0, 0, 0.1));
   letter-spacing: 1;
   background-size: cover;
+  background: url("file:///home/joao/Pictures/Capturas%20de%20tela/Captura%20de%20tela%20de%202023-06-03%2022-27-39.png");
 }
 
 .anim_container_outer {
@@ -170,9 +171,16 @@ body {
 }
 
 .sf6 .chips {
-  top: 108px;
-  width: 270px;
+  top: 106px;
   height: 32px;
+}
+
+.sf6.offline .chips {
+  width: 450px;
+}
+
+.sf6.online .chips {
+  width: 270px;
   background: var(--bg-color);
   border-radius: calc(var(--border-radius) / 2);
 }
@@ -186,8 +194,17 @@ body {
   left: 380px;
 }
 
-.sf6 .p1.chips {
+.sf6 .chip {
+  height: 32px;
+}
+
+.sf6.online .p1.chips {
   left: 200px;
+  justify-content: left;
+}
+
+.sf6.offline .p1.chips {
+  left: 8px;
   justify-content: left;
 }
 
@@ -197,10 +214,34 @@ body {
   justify-content: left;
 }
 
-.sf6 .p2.chips {
+.sf6.online .p2.chips {
   left: unset;
   right: 200px;
   justify-content: right;
+}
+
+.sf6.offline .p2.chips {
+  left: unset;
+  right: 8px;
+  justify-content: right;
+}
+
+.sf6.online .seed {
+  position: absolute;
+  top: 106px;
+}
+
+.sf6.online .p1 .seed {
+  left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.sf6.online .p2 .seed {
+  left: unset;
+  right: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .chip .text:not(.text_empty) {
@@ -219,6 +260,12 @@ body {
 .sf6 .chip .text:not(.text_empty) {
   font-size: 20px;
   height: 100%;
+}
+
+.sf6.online .seed.chip .text:not(.text_empty) {
+  margin: 0;
+  border-radius: 0;
+  width: 130px;
 }
 
 .fgc .name_twitter {

--- a/layout/scoreboard/index.js
+++ b/layout/scoreboard/index.js
@@ -145,6 +145,17 @@ LoadEverything().then(() => {
               $(`.p${t + 1}.container .sponsor-container`),
               `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
             );
+
+            if ($(".sf6.online").length > 0) {
+              console.log("hi");
+              console.log(player.twitter);
+              console.log(player.pronoun);
+              if (!player.twitter && !player.pronoun) {
+                gsap.to($(`.p${t + 1}.chips`), { autoAlpha: 0 });
+              } else {
+                gsap.to($(`.p${t + 1}.chips`), { autoAlpha: 1 });
+              }
+            }
           }
         }
       }

--- a/layout/scoreboard/sf6_offline.html
+++ b/layout/scoreboard/sf6_offline.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="../include/globals.js"></script>
+    <link rel="stylesheet" href="../main.css" />
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body class="fgc sf6 offline">
+    <div class="logo"></div>
+
+    <div class="anim_container_outer">
+      <div class="anim_container_inner">
+        <div class="info top container">
+          <div class="tournament_name"></div>
+        </div>
+
+        <div class="p1 player container">
+          <div class="icon avatar"></div>
+          <div class="icon online_avatar"></div>
+          <div class="flagcountry"></div>
+          <div class="flagstate"></div>
+          <div class="sponsor_icon"></div>
+          <div class="name_twitter">
+            <div class="name"></div>
+          </div>
+          <div class="score"></div>
+        </div>
+        <div class="p2 player container">
+          <div class="icon avatar"></div>
+          <div class="icon online_avatar"></div>
+          <div class="flagcountry"></div>
+          <div class="flagstate"></div>
+          <div class="sponsor_icon"></div>
+          <div class="name_twitter">
+            <div class="name"></div>
+          </div>
+          <div class="score"></div>
+        </div>
+
+        <div class="info bottom container">
+          <div class="phase"></div>
+          <div class="match"></div>
+        </div>
+
+        <div class="p1 chips">
+          <div class="seed chip"></div>
+          <div class="twitter chip"></div>
+          <div class="pronoun chip"></div>
+        </div>
+
+        <div class="p2 chips">
+          <div class="seed chip"></div>
+          <div class="twitter chip"></div>
+          <div class="pronoun chip"></div>
+        </div>
+      </div>
+    </div>
+
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/layout/scoreboard/sf6_online.html
+++ b/layout/scoreboard/sf6_online.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="../main.css" />
     <link rel="stylesheet" href="./index.css" />
   </head>
-  <body class="fgc sf6">
+  <body class="fgc sf6 online">
     <div class="logo"></div>
 
     <div class="anim_container_outer">
@@ -43,15 +43,19 @@
         </div>
 
         <div class="p1 chips">
-          <div class="seed chip"></div>
           <div class="twitter chip"></div>
           <div class="pronoun chip"></div>
         </div>
+        <div class="p1">
+          <div class="seed chip"></div>
+        </div>
 
         <div class="p2 chips">
-          <div class="seed chip"></div>
           <div class="twitter chip"></div>
           <div class="pronoun chip"></div>
+        </div>
+        <div class="p2">
+          <div class="seed chip"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
There are now 2 separate layouts for SF6:
- Offline: Just place chips on the sides of the screen, since there isn't anything under the player HP side towards the screen edges.
- Online: cover LP with seed, when available. Divided the container into 2 because of platform icon. Hide container when there's no Twitter or pronoun.