### PR TITLE
ContentResolver

### DIFF
--- a/layout/include/globals.js
+++ b/layout/include/globals.js
@@ -687,3 +687,23 @@ function nextPow2(v) {
   }
   return p;
 }
+
+/**
+ * Stores content to be added to the DOM with SetInnerHtml later
+ */
+class ContentResolver {
+  constructor () {
+      this.list = [];
+  }
+
+  add(selector, value){
+      this.list.push({s: selector, v: value});
+      return ""
+  }
+
+  resolve(){
+      for (let element of this.list){
+          SetInnerHtml($(element.s), element.v);
+      }
+  }
+}


### PR DESCRIPTION
Added a little class that allows you to store content and an associated html selector so that the content is later added through SetInnerHtml. In procedural layouts, where we need a loop to generate html, and then another loop for SetInnerHtml calls, this removes the need for that second loop, as you can simply store the content while generating the html, and then simply call .resolve() to have the content added automatically. 

Not really adding a feature, but making scripts potentially cleaner.