### PR TITLE
Add in ability to clear player widgets from web server

### DIFF
--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -763,6 +763,11 @@ class TSHScoreboardWidget(QDockWidget):
             ]
             scoreContainers[team].setValue(
                 scoreContainers[team].value()+change)
+    
+    def CommandClearAll(self):
+        for t, team in enumerate([self.team1playerWidgets, self.team2playerWidgets]):
+            for i, p in enumerate(team):
+                p.Clear()
 
     def ClearScore(self):
         for c in self.scoreColumn.findChildren(QComboBox):

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -270,10 +270,7 @@ class WebServer(QThread):
     # Resets scores
     @app.route('/reset-scores')
     def reset_scores():
-        WebServer.scoreboard.signals.UpdateSetData.emit({
-            "team1score": 0,
-            "team2score": 0
-        })
+        WebServer.scoreboard.ResetScore()
         return "OK"
 
     # Resets scores, match, phase, and losers status
@@ -282,6 +279,12 @@ class WebServer(QThread):
         WebServer.scoreboard.ClearScore()
         WebServer.scoreboard.scoreColumn.findChild(
             QSpinBox, "best_of").setValue(0)
+        return "OK"
+    
+    # Resets scores, match, phase, and losers status
+    @app.route('/reset-players')
+    def reset_players():
+        WebServer.scoreboard.CommandClearAll()
         return "OK"
 
     # Resets all values
@@ -292,6 +295,7 @@ class WebServer(QThread):
             QSpinBox, "best_of").setValue(0)
         WebServer.scoreboard.playerNumber.setValue(1)
         WebServer.scoreboard.charNumber.setValue(1)
+        WebServer.scoreboard.CommandClearAll()
         return "OK"
 
     @app.route('/', defaults=dict(filename=None))


### PR DESCRIPTION
Was requested on Discord.

Added in the ability to reset player widgets from the web server to make quick swapping that much easier. Also allows us to get a little bit closer to making an external control app.