### PR TITLE
Minor fix on JinTracker: Reordered function execution to center player name

### DIFF
--- a/layout/scoreboard_JinTracker/index.js
+++ b/layout/scoreboard_JinTracker/index.js
@@ -31,6 +31,11 @@ LoadEverything().then(() => {
         for (const [p, player] of [team.player["1"]].entries()) {
           if (player) {
             SetInnerHtml(
+              $(`.p${t + 1}.container .placeholder_container`),
+              player.character[1].name ? `<div class='placeholder'></div>` : ""
+            );
+
+            SetInnerHtml(
               $(`.p${t + 1}.container .name`),
               `
             <span>
@@ -48,11 +53,6 @@ LoadEverything().then(() => {
               player.country.asset
                 ? `<div class='flag' style='background-image: url(../../${player.country.asset.toLowerCase()})'></div>`
                 : ""
-            );
-
-            SetInnerHtml(
-              $(`.p${t + 1}.container .placeholder_container`),
-              player.character[1].name ? `<div class='placeholder'></div>` : ""
             );
 
             let score = [data.score.score_left, data.score.score_right];


### PR DESCRIPTION
Hi, in a rare instance I noticed that the name doesn't get centered properly when the character image is shown. I think this was due to the name getting set before the character image placeholder space was set, so I reordered their order of execution. Thanks!