### PR TITLE
Add the ability to remotely call sets to load from the Web Server

### DIFF
--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -411,6 +411,7 @@ class TSHGameAssetManager(QObject):
                         "name": self.parent().selectedGame.get("name"),
                         "smashgg_id": self.parent().selectedGame.get("smashgg_game_id"),
                         "codename": self.parent().selectedGame.get("codename"),
+                        "game_logo": self.parent().selectedGame.get("path")+"/base_files/logo.png",
                     })
 
                     self.parent().UpdateCharacterModel()

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -781,7 +781,7 @@ class TSHScoreboardWidget(QDockWidget):
 
         # If you switched sets and it was still finishing an async update call
         # Avoid loading data from the previous set
-        if data.get("id") != self.lastSetSelected:
+        if str(data.get("id")) != str(self.lastSetSelected):
             return
 
         StateManager.BlockSaving()

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -306,7 +306,7 @@ class WebServer(QThread):
         WebServer.scoreboard.CommandClearAll()
         return "OK"
     
-    # Ticks score of Team specified down by 1 point
+    # Loads a set remotely by providing a set ID to pull from the data provider
     @app.route('/load-set')
     def load_set():
         if request.args.get('set') is not None:

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -7,6 +7,7 @@ from flask_cors import CORS, cross_origin
 import json
 from .StateManager import StateManager
 from .TSHStatsUtil import TSHStatsUtil
+from .TSHTournamentDataProvider import TSHTournamentDataProvider
 from .SettingsManager import SettingsManager
 
 
@@ -303,6 +304,20 @@ class WebServer(QThread):
         WebServer.scoreboard.playerNumber.setValue(1)
         WebServer.scoreboard.charNumber.setValue(1)
         WebServer.scoreboard.CommandClearAll()
+        return "OK"
+    
+    # Ticks score of Team specified down by 1 point
+    @app.route('/load-set')
+    def load_set():
+        if request.args.get('set') is not None:
+            WebServer.scoreboard.signals.NewSetSelected.emit(
+                json.loads(
+                    json.dumps({
+                        'id': request.args.get('set', default='0', type=str),
+                        'auto_update': "set"
+                        })
+                )
+            )
         return "OK"
 
     @app.route('/', defaults=dict(filename=None))


### PR DESCRIPTION
This PR adds the ability to specify a set ID to call to the web server to have TSH load it remotely. This can be good if you want to manually prepare the calls before hand or do it from another PC (Also potentially a future web tool to interface with TSH). The only weird change is to checking against the "lastSetSelected" variable as this didn't appear to work properly when making calls as _technically_ the set ID can have letters making it a string for StartGG (See preview sets if a pool has not started yet), so I changed it to be string checking as it will be more reliable in cases like that and works with remote calling and selecting via the set selector.

Tested against GOML 2023 Melee and Ultimate with no real issues found when testing.