### PR TITLE
Add and Convert to Loguru Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ build/main/*
 TSH_old.exe
 main.spec
 *.tmp
+logs/*

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -13,3 +13,4 @@ python-dateutil
 pynput
 pyside6
 cloudscraper
+loguru

--- a/src/Helpers/TSHBadWordFilter.py
+++ b/src/Helpers/TSHBadWordFilter.py
@@ -8,6 +8,7 @@ import traceback
 import os
 from collections import defaultdict
 from typing import List, Set, Tuple
+from loguru import logger
 
 
 def remove_accents_lower(input_str):
@@ -66,7 +67,7 @@ class TSHBadWordFilter():
                 newWords = set(words)
                 langs[f.split(".")[0]] = newWords
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         # Commenting this block until we have a better performing alternative
         # This is too time consuming in cases like loading a huge bracket
@@ -153,7 +154,7 @@ class TSHBadWordFilter():
                 langTests.add(lang)
                 continue
 
-        print(f"TSHBadWordFilter: using filters [{', '.join(langTests)}]")
+        logger.info(f"TSHBadWordFilter: using filters [{', '.join(langTests)}]")
 
         dividers = [" ", "_", ",", ".", "/", "-", "\\", "*"]
         testString = remove_accents_lower(value)
@@ -217,7 +218,7 @@ class TSHBadWordFilter():
                 newString += value[stringStart:]
 
         if value != newString:
-            print(value, "->", newString)
+            logger.info(value, "->", newString)
 
         return newString
 
@@ -253,7 +254,7 @@ class TSHBadWordFilter():
                          encoding="utf-8").read().splitlines()
             return set([remove_accents_lower(w) for w in words if len(w) > 0])
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
 
 TSHBadWordFilter.LoadBadWordList()

--- a/src/Helpers/TSHCountryHelper.py
+++ b/src/Helpers/TSHCountryHelper.py
@@ -9,6 +9,7 @@ from .TSHDictHelper import deep_get
 from ..TournamentDataProvider import TournamentDataProvider
 from .TSHLocaleHelper import TSHLocaleHelper
 import json
+from loguru import logger
 
 
 class TSHCountryHelperSignals(QObject):
@@ -52,12 +53,12 @@ class TSHCountryHelper(QObject):
                             './assets/countries+states+cities.json'
                         )
 
-                        print("Countries file updated")
+                        logger.info("Countries file updated")
                         TSHCountryHelper.LoadCountries()
                     except:
-                        print("Countries files download failed")
+                        logger.error("Countries files download failed")
                 except Exception as e:
-                    print(
+                    logger.error(
                         "Could not update /assets/countries+states+cities.json: "+str(e))
         downloaderThread = DownloaderThread(self)
         downloaderThread.start()
@@ -162,7 +163,7 @@ class TSHCountryHelper(QObject):
             TSHCountryHelper.signals.countriesUpdated.emit()
         except:
             TSHCountryHelper.countries_json = {}
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
     def FindState(countryCode, city):
         # State explicit?

--- a/src/Helpers/TSHLocaleHelper.py
+++ b/src/Helpers/TSHLocaleHelper.py
@@ -152,7 +152,7 @@ class TSHLocaleHelper(QObject):
     def GetRemaps(language: str):
         for remap, langs in TSHLocaleHelper.remapping.items():
             if language.replace('-', '_') in langs:
-                logger.info("Loaded remap: ", remap)
+                logger.info("Loaded remap: " + str(remap))
                 return remap
         return None
 

--- a/src/Helpers/TSHLocaleHelper.py
+++ b/src/Helpers/TSHLocaleHelper.py
@@ -5,6 +5,7 @@ from qtpy.QtGui import *
 import os
 import traceback
 from copy import deepcopy
+from loguru import logger
 
 from src.SettingsManager import SettingsManager
 from src.StateManager import StateManager
@@ -36,7 +37,7 @@ class TSHLocaleHelper(QObject):
         else:
             current_locale = QtCore.QLocale().uiLanguages()
 
-        print("OS locale", current_locale)
+        logger.info("OS locale: " + str(current_locale))
 
         oldTranslator = TSHLocaleHelper.translator
 
@@ -131,7 +132,7 @@ class TSHLocaleHelper(QObject):
             TSHLocaleHelper.matchNames = term_names.get("match")
             TSHLocaleHelper.phaseNames = term_names.get("phase")
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         # Load user round names in a separate try/catch
         try:
@@ -146,12 +147,12 @@ class TSHLocaleHelper(QObject):
             TSHLocaleHelper.phaseNames.update(term_names["phase"])
             TSHLocaleHelper.matchNames.update(term_names["match"])
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
     def GetRemaps(language: str):
         for remap, langs in TSHLocaleHelper.remapping.items():
             if language.replace('-', '_') in langs:
-                print("Loaded remap: ", remap)
+                logger.info("Loaded remap: ", remap)
                 return remap
         return None
 

--- a/src/TSHAlertNotification.py
+++ b/src/TSHAlertNotification.py
@@ -7,6 +7,7 @@ import os
 import traceback
 import json
 import time
+from loguru import logger
 
 
 class TSHAlertNotificationSignals(QObject):
@@ -31,13 +32,13 @@ class TSHAlertNotification(QObject):
                         "https://raw.githubusercontent.com/joaorb64/TournamentStreamHelper/main/assets/alerts.json")
                     alerts = json.loads(response.text)
                 except Exception as e:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
                 try:
                     alerts_red = json.load(
                         open('./user_data/alerts_red.json', encoding='utf-8'))
                 except Exception as e:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
                 filtered = {}
 
@@ -100,7 +101,7 @@ class TSHAlertNotification(QObject):
             alerts_red = json.load(
                 open('./user_data/alerts_red.json', encoding='utf-8'))
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         if alerts_red is not None:
             alerts_red.append(id)

--- a/src/TSHAssetDownloader.py
+++ b/src/TSHAssetDownloader.py
@@ -12,6 +12,7 @@ import py7zr
 import urllib
 import json
 import os
+from loguru import logger
 
 
 class IconDelegate(QStyledItemDelegate):
@@ -61,7 +62,7 @@ class TSHAssetDownloader(QObject):
                     TSHAssetDownloader.instance.signals.AssetUpdates.emit(
                         updates)
                 except:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
         thread = AssetUpdatesThread(self)
         thread.start()
@@ -337,7 +338,7 @@ class TSHAssetDownloader(QObject):
             data = response.read()
             return ([index, data])
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
             return (None)
 
     def DownloadGameIconComplete(self, result):
@@ -351,19 +352,19 @@ class TSHAssetDownloader(QObject):
                     if self.select.model().index(i, 0).data(Qt.ItemDataRole.UserRole) == result[0]:
                         self.select.setItemIcon(i, QIcon(pix))
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
             return (None)
 
     def DownloadAssetsWorker(self, files, progress_callback):
         totalSize = sum(sum(f["size"] for f in fileList) for fileList in files)
         downloaded = 0
 
-        print("Files to download:", files)
+        logger.info("Files to download:" + str(files))
 
         for i, fileList in enumerate(files):
             for f in fileList:
                 with open("user_data/games/"+f["name"], 'wb') as downloadFile:
-                    print("Downloading "+f["name"])
+                    logger.info("Downloading "+f["name"])
                     progress_callback.emit(QApplication.translate(
                         "app", "Downloading {0}... ({1}/{2})").format(f["name"], i+1, len(files)))
 
@@ -385,7 +386,7 @@ class TSHAssetDownloader(QObject):
                             min(int(downloaded/totalSize*100), 99))
                     downloadFile.close()
 
-                    print("Download OK")
+                    logger.info("Download OK")
 
             is7z = ".7z" in fileList[0]["name"]
 
@@ -415,11 +416,11 @@ class TSHAssetDownloader(QObject):
                     shutil.move("./user_data/games/" +
                                 f["name"], f["extractpath"])
 
-            print("Extract OK")
+            logger.info("Extract OK")
 
         progress_callback.emit(100)
 
-        print("All OK")
+        logger.info("All OK")
 
     def DownloadAssetsProgress(self, n):
         if type(n) == int:

--- a/src/TSHBracket.py
+++ b/src/TSHBracket.py
@@ -1,5 +1,6 @@
 import math
 from .Helpers.TSHLocaleHelper import TSHLocaleHelper
+from loguru import logger
 
 class BracketSet():
     BYE = -1
@@ -134,7 +135,7 @@ class Bracket():
                         if int(k) < 0 and abs(int(k))%2 == 1: targetIdW = 1
                         _set.winNextSlot = targetIdW
                     except Exception as e:
-                        print(e)
+                        logger.error(e)
                     try:
                         if abs(roundNum)%4 == 0:
                             _set.loseNext = self.rounds[str(-int(2*(roundNum)))][(int(len(round)/2)+j)%len(round)]
@@ -152,7 +153,7 @@ class Bracket():
                         
                         _set.loseNextSlot = targetIdL
                     except Exception as e:
-                        print(e)
+                        logger.error(e)
             else:
                 for j, _set in enumerate(round):
                     try:
@@ -164,7 +165,7 @@ class Bracket():
                         if int(k) < 0 and abs(int(k))%2 == 1: targetIdW = 1
                         _set.winNextSlot = targetIdW
                     except Exception as e:
-                        print(e)
+                        logger.error(e)
         
         # Connect losers to winners for grand finals
         lastLosers = min([int(r) for r in self.rounds.keys()])

--- a/src/TSHBracketView.py
+++ b/src/TSHBracketView.py
@@ -6,6 +6,7 @@ import json
 from .TSHBracket import *
 from .TSHPlayerList import *
 import traceback
+from loguru import logger
 
 # Checks if a number is power of 2
 def is_power_of_two(n):
@@ -116,7 +117,7 @@ class BracketSetWidget(QWidget):
                 else:
                     self.name[0].setText("")
             except:
-                print(traceback.format_exc())
+                logger.error(traceback.format_exc())
 
             try:
                 if (self.bracketSet.playerIds[1]-1) < len(self.bracketView.playerList.slotWidgets) and self.bracketSet.playerIds[1] > 0:
@@ -129,7 +130,7 @@ class BracketSetWidget(QWidget):
                 else:
                     self.name[1].setText("")
             except:
-                print(traceback.format_exc())
+                logger.error(traceback.format_exc())
 
             if self.bracketSet.finished is not None:
                 self.finished.blockSignals(True)
@@ -338,7 +339,7 @@ class TSHBracketView(QGraphicsView):
             try:
                 losersRounds = int(math.log2(limitExportNumber)) + int(math.log2((limitExportNumber-1)/2)) + 2
             except:
-                print(traceback.format_exc())
+                logger.error(traceback.format_exc())
                 losersRounds = 0
 
             if self.bracketWidget.progressionsIn.value() > 0:
@@ -620,7 +621,7 @@ class TSHBracketView(QGraphicsView):
                             ])
                         )
                 except:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
         
         pen = QPen(Qt.gray, 4, Qt.SolidLine)
         pen2 = QPen(Qt.black, 6, Qt.SolidLine)

--- a/src/TSHBracketWidget.py
+++ b/src/TSHBracketWidget.py
@@ -202,7 +202,7 @@ class TSHBracketWidget(QDockWidget):
         StateManager.ReleaseSaving()
 
     def UpdatePhases(self, phases):
-        logger.info("Phases :" + str(phases))
+        logger.info("Phases: " + str(phases))
         self.phaseSelection.clear()
         self.phaseSelection.addItem("", {})
 

--- a/src/TSHBracketWidget.py
+++ b/src/TSHBracketWidget.py
@@ -13,6 +13,7 @@ from .TSHBracketView import TSHBracketView
 from .TSHPlayerList import TSHPlayerList
 from .TSHBracket import *
 import traceback
+from loguru import logger
 
 # Checks if a number is power of 2
 
@@ -201,7 +202,7 @@ class TSHBracketWidget(QDockWidget):
         StateManager.ReleaseSaving()
 
     def UpdatePhases(self, phases):
-        print("phases", phases)
+        logger.info("Phases :" + str(phases))
         self.phaseSelection.clear()
         self.phaseSelection.addItem("", {})
 
@@ -218,7 +219,7 @@ class TSHBracketWidget(QDockWidget):
         self.phaseGroupSelection.clear()
 
         if self.phaseSelection.currentData() != None:
-            print(self.phaseSelection.currentData().get("groups", []))
+            logger.info(str(self.phaseSelection.currentData().get("groups", [])))
             for phaseGroup in self.phaseSelection.currentData().get("groups", []):
                 self.phaseGroupSelection.addItem(
                     phaseGroup.get("name"), phaseGroup)
@@ -268,7 +269,7 @@ class TSHBracketWidget(QDockWidget):
         self.playerList.signals.DataChanged.disconnect()
 
         try:
-            print(phaseGroupData)
+            logger.info("Phase Group Data: " + str(phaseGroupData))
 
             if phaseGroupData.get("progressionsIn", {}) != None:
                 self.progressionsIn.setValue(
@@ -328,13 +329,13 @@ class TSHBracketWidget(QDockWidget):
                         self.bracket.rounds[roundIndex][s].finished = _set.get(
                             "finished")
                     except Exception as e:
-                        print(e)
+                        logger.error(e)
 
             QGuiApplication.processEvents()
             self.bracket.UpdateBracket()
             self.bracketView.Update()
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
         finally:
             StateManager.ReleaseSaving()
             self.playerList.signals.DataChanged.connect(

--- a/src/TSHCommentaryWidget.py
+++ b/src/TSHCommentaryWidget.py
@@ -3,6 +3,7 @@ from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 from qtpy.QtCore import *
 from qtpy import uic
+from loguru import logger
 
 from .TSHScoreboardPlayerWidget import *
 from .Helpers.TSHBadWordFilter import TSHBadWordFilter
@@ -172,8 +173,8 @@ class TSHCommentaryWidget(QDockWidget):
                                 if processed_line and processed_line not in c.pronoun_list:
                                     c.pronoun_list.append(processed_line)
                     except Exception as e:
-                        print(f"ERROR: Did not find {file}")
-                        print(traceback.format_exc())
+                        logger.error(f"ERROR: Did not find {file}")
+                        logger.error(traceback.format_exc())
                 c.pronoun_model = QStringListModel()
                 c.pronoun_completer.setModel(c.pronoun_model)
                 c.pronoun_model.setStringList(c.pronoun_list)

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -10,6 +10,7 @@ import threading
 from .Helpers.TSHLocaleHelper import TSHLocaleHelper
 from .Workers import Worker
 from PIL import Image
+from loguru import logger
 
 import requests
 
@@ -67,11 +68,11 @@ class TSHGameAssetManager(QObject):
                             './assets/characters.json'
                         )
 
-                        print("startgg characters file updated")
+                        logger.info("startgg characters file updated")
                     except:
-                        print("Characters file download failed")
+                        logger.error("Characters file download failed")
                 except Exception as e:
-                    print("Could not update /assets/characters.json: "+str(e))
+                    logger.error("Could not update /assets/characters.json: "+str(e))
         thread = DownloaderThread(self)
         thread.start()
 
@@ -111,14 +112,14 @@ class TSHGameAssetManager(QObject):
                         for dir in assetDirs:
                             if os.path.isdir("./user_data/games/"+game+"/"+dir):
                                 if os.path.isfile("./user_data/games/"+game+"/"+dir+"/config.json"):
-                                    print(
+                                    logger.info(
                                         "Found asset config for ["+game+"]["+dir+"]")
                                     f = open("./user_data/games/"+game+"/"+dir +
                                              "/config.json", encoding='utf-8')
                                     self.parent().games[game]["assets"][dir] = \
                                         json.load(f)
                                 else:
-                                    print("No config file for "+game+" - "+dir)
+                                    logger.error("No config file for "+game+" - "+dir)
 
                         # Load translated names
                         # Translate game name
@@ -136,7 +137,7 @@ class TSHGameAssetManager(QObject):
                                 self.parent(
                                 ).games[game]["name"] = game_name
                     else:
-                        print("Game config for "+game+" doesn't exist.")
+                        logger.info("Game config for "+game+" doesn't exist.")
                 # print(self.parent().games)
                 self.parent().signals.onLoadAssets.emit()
 
@@ -186,7 +187,7 @@ class TSHGameAssetManager(QObject):
                         self.parent().threadpool.waitForDone()
                         return
 
-                    print("Changed to game: "+game)
+                    logger.info("Changed to game: "+game)
 
                     gameObj = self.parent().games.get(game, {})
                     self.parent().selectedGame = gameObj
@@ -231,7 +232,7 @@ class TSHGameAssetManager(QObject):
                                 try:
                                     number = int(f[numberStart:numberEnd])
                                 except:
-                                    print(f)
+                                    logger.error(f)
                                     pass
                                 self.parent().stockIcons[c][number] = QImage(
                                     './user_data/games/'+game+'/'+assetsKey+'/'+f).scaledToWidth(
@@ -239,7 +240,7 @@ class TSHGameAssetManager(QObject):
                                         Qt.TransformationMode.SmoothTransformation
                                 )
 
-                        print("Loaded stock icons")
+                        logger.info("Loaded stock icons")
 
                         self.parent().skins = {}
 
@@ -297,7 +298,7 @@ class TSHGameAssetManager(QObject):
                                     if size.height() != -1:
                                         heights[assetsKey].append(
                                             size.height())
-                            print("Character "+c+" has " +
+                            logger.info("Character "+c+" has " +
                                   str(len(self.parent().skins[c]))+" skins")
 
                         # Set average size
@@ -310,7 +311,7 @@ class TSHGameAssetManager(QObject):
                                             "y": sum(heights[assetsKey])/len(heights[assetsKey])
                                         }
                                 except:
-                                    print(traceback.format_exc())
+                                    logger.error(traceback.format_exc())
 
                         # Set complete
                         for assetsKey in list(gameObj.get("assets", {}).keys()):
@@ -327,7 +328,7 @@ class TSHGameAssetManager(QObject):
 
                                 gameObj["assets"][assetsKey]["complete"] = complete
                             except:
-                                print(traceback.format_exc())
+                                logger.error(traceback.format_exc())
 
                         # Get biggest complete pack
                         assetsKey = "base_files/icon"
@@ -343,7 +344,7 @@ class TSHGameAssetManager(QObject):
                                     biggestAverage = size
 
                         self.parent().biggestCompletePack = assetsKey
-                        print("Biggest complete assets:", assetsKey)
+                        logger.info("Biggest complete assets: " + assetsKey)
 
                         # Get stage icon
                         assetsKey = None
@@ -405,7 +406,7 @@ class TSHGameAssetManager(QObject):
                                 self.parent(
                                 ).characters[c]["en_name"] = en_name
                         except:
-                            print(traceback.format_exc())
+                            logger.error(traceback.format_exc())
 
                     StateManager.Set(f"game", {
                         "name": self.parent().selectedGame.get("name"),
@@ -419,7 +420,7 @@ class TSHGameAssetManager(QObject):
                     self.parent().UpdateStageModel()
                     self.parent().signals.onLoad.emit()
                 except:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
                 finally:
                     self.parent().threadpool.waitForDone()
                     self.lock.unlock()
@@ -495,7 +496,7 @@ class TSHGameAssetManager(QObject):
                 worker.signals.result.connect(self.LoadStageImageComplete)
                 self.threadpool.start(worker)
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
     def LoadStageImage(self, stage, item, progress_callback):
         try:
@@ -525,7 +526,7 @@ class TSHGameAssetManager(QObject):
         except Exception as e:
             img = QPixmap("./assets/icons/cancel.svg").scaled(32, 32)
             icon = QIcon(img)
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
             return ([item, icon])
 
     def LoadStageImageComplete(self, result):
@@ -534,7 +535,7 @@ class TSHGameAssetManager(QObject):
                 if result[0] and result[1]:
                     result[0].setIcon(result[1])
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
             return (None)
 
     def UpdateCharacterModel(self):
@@ -568,7 +569,7 @@ class TSHGameAssetManager(QObject):
 
             self.characterModel.sort(0)
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
     def UpdateSkinModel(self):
         self.skinModels = {}
@@ -628,7 +629,7 @@ class TSHGameAssetManager(QObject):
                         skin_name_en = skinNameData.get(
                             skinIndex, {}).get("name")
                 except:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
                 assetData["name"] = skin_name
                 assetData["en_name"] = skin_name_en
@@ -793,7 +794,7 @@ class TSHGameAssetManager(QObject):
 
             return ([(allItem[i], icons[i]) for i in range(len(allItem))])
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
             return (None)
 
     def LoadSkinImagesComplete(self, results):
@@ -803,7 +804,7 @@ class TSHGameAssetManager(QObject):
                     if result[0] and result[1]:
                         result[0].setIcon(result[1])
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
             return (None)
 
     def GetCharacterAssets(self, characterCodename: str, skin: int, assetpack: str = None):
@@ -949,7 +950,7 @@ class TSHGameAssetManager(QObject):
                         charFiles[assetKey]["average_size"] = asset.get(
                             "average_size")
                 except Exception as e:
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
         return (charFiles)
 

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -303,7 +303,7 @@ class TSHGameAssetManager(QObject):
 
                         # Set average size
                         for assetsKey in list(gameObj.get("assets", {}).keys()):
-                            if assetsKey != "base_files":
+                            if assetsKey != "base_files" and assetsKey != "stage_icon":
                                 try:
                                     if len(widths[assetsKey]) > 0 and len(heights[assetsKey]) > 0:
                                         gameObj["assets"][assetsKey]["average_size"] = {
@@ -500,7 +500,7 @@ class TSHGameAssetManager(QObject):
 
     def LoadStageImage(self, stage, item, progress_callback):
         try:
-            if stage.get("path"):
+            if stage.get("path") and os.path.exists(stage.get("path")):
                 img = Image.open(stage.get("path"))
 
                 resizeMultiplier = 1
@@ -521,8 +521,6 @@ class TSHGameAssetManager(QObject):
                 icon = QIcon(pix)
 
                 return ([item, icon])
-            else:
-                raise
         except Exception as e:
             img = QPixmap("./assets/icons/cancel.svg").scaled(32, 32)
             icon = QIcon(img)
@@ -874,8 +872,9 @@ class TSHGameAssetManager(QObject):
 
                         if len(eyesights.keys()) > 0:
                             if str(skin) in eyesights:
-                                charFiles[assetKey]["eyesight"] = eyesights.get(
-                                    str(skin))
+                                if assetKey in charFiles:
+                                    charFiles[assetKey]["eyesight"] = eyesights.get(
+                                        str(skin))
                             else:
                                 charFiles[assetKey]["eyesight"] = list(
                                     eyesights.values())[0]
@@ -886,8 +885,9 @@ class TSHGameAssetManager(QObject):
 
                         if len(rescaling_factor.keys()) > 0:
                             if str(skin) in rescaling_factor:
-                                charFiles[assetKey]["rescaling_factor"] = rescaling_factor.get(
-                                    str(skin))
+                                if assetKey in charFiles:
+                                    charFiles[assetKey]["rescaling_factor"] = rescaling_factor.get(
+                                        str(skin))
                             else:
                                 charFiles[assetKey]["rescaling_factor"] = rescaling_factor.get(
                                     "0", 1)
@@ -898,8 +898,9 @@ class TSHGameAssetManager(QObject):
 
                         if len(unflippable.keys()) > 0:
                             if str(skin) in unflippable:
-                                charFiles[assetKey]["unflippable"] = unflippable.get(
-                                    str(skin))
+                                if assetKey in charFiles:
+                                    charFiles[assetKey]["unflippable"] = unflippable.get(
+                                        str(skin))
                             else:
                                 charFiles[assetKey]["unflippable"] = list(
                                     unflippable.values())[0]
@@ -943,12 +944,14 @@ class TSHGameAssetManager(QObject):
                         #             metadata.values())[0]
 
                     if asset.get("uncropped_edge"):
-                        charFiles[assetKey]["uncropped_edge"] = asset.get(
-                            "uncropped_edge")
+                        if assetKey in charFiles:
+                            charFiles[assetKey]["uncropped_edge"] = asset.get(
+                                "uncropped_edge")
 
                     if asset.get("average_size"):
-                        charFiles[assetKey]["average_size"] = asset.get(
-                            "average_size")
+                        if assetKey in charFiles:
+                            charFiles[assetKey]["average_size"] = asset.get(
+                                "average_size")
                 except Exception as e:
                     logger.error(traceback.format_exc())
 

--- a/src/TSHHotkeys.py
+++ b/src/TSHHotkeys.py
@@ -11,6 +11,7 @@ import copy
 import pynput
 from .SettingsManager import SettingsManager
 from .Helpers.TSHLocaleHelper import TSHLocaleHelper
+from loguru import logger
 
 class TSHHotkeysSignals(QObject):
     team1_score_up = Signal()
@@ -71,7 +72,7 @@ class TSHHotkeys(QObject):
     
     def HotkeyTriggered(self, k, v):
         if not SettingsManager.Get("hotkeys.hotkeys_enabled", True) == False:
-            print(f"Activated {k} by pressing {v}")
+            logger.info(f"Activated {k} by pressing {v}")
             getattr(self.signals, k).emit()
     
     def LoadUserHotkeys(self):
@@ -81,7 +82,7 @@ class TSHHotkeys(QObject):
         # Update keys
         self.loaded_keys.update((k,v) for k,v in user_keys.items() if k in self.keys)
 
-        print("User hotkeys loaded")
+        logger.info("User hotkeys loaded")
     
     def qshortcut_to_pynput(qshortcut_str):
         try:
@@ -99,8 +100,8 @@ class TSHHotkeys(QObject):
 
             return "+".join(parts)
         except:
-            print(f"Could not convert qshortcut {qshortcut_str} to pynput")
-            print(traceback.format_exc())
+            logger.error(f"Could not convert qshortcut {qshortcut_str} to pynput")
+            logger.error(traceback.format_exc())
             return None
 
 TSHHotkeys.instance = TSHHotkeys()

--- a/src/TSHPlayerDB.py
+++ b/src/TSHPlayerDB.py
@@ -8,6 +8,7 @@ from qtpy.QtCore import *
 import re
 import csv
 import traceback
+from loguru import logger
 
 from .TSHGameAssetManager import TSHGameAssetManager
 
@@ -44,14 +45,14 @@ class TSHPlayerDB:
                                 player.get("mains", "{}"))
                         except:
                             player["mains"] = {}
-                            print(traceback.format_exc())
+                            logger.error(traceback.format_exc())
 
             TSHPlayerDB.SetupModel()
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
     def AddPlayers(players, overwrite=False):
-        print(f"Adding players to DB: {len(players)}")
+        logger.info(f"Adding players to DB: {len(players)}")
         for player in players:
             if player is not None:
                 tag = player.get(
@@ -92,7 +93,7 @@ class TSHPlayerDB:
                             mains.update(player.get("mains", {}))
                             player["mains"] = mains
                         except:
-                            print(traceback.format_exc())
+                            logger.error(traceback.format_exc())
                     TSHPlayerDB.database[tag] = player
 
         TSHPlayerDB.SaveDB()
@@ -145,9 +146,9 @@ class TSHPlayerDB:
                                         try:
                                             skin = int(main[1])
                                         except:
-                                            print(
+                                            logger.error(
                                                 f'Local DB error: Player {player.get("gamerTag")} has an invalid skin for character {main[0]}')
-                                            print(traceback.format_exc())
+                                            logger.error(traceback.format_exc())
                                         main[1] = skin
 
                                     if playerMains[0][0] in TSHGameAssetManager.instance.characters.keys():
@@ -166,9 +167,9 @@ class TSHPlayerDB:
 
                         TSHPlayerDB.model.appendRow(item)
                     except:
-                        print(
+                        logger.error(
                             f'Error loading player from local DB: {player.get("gamerTag")}')
-                        print(traceback.format_exc())
+                        logger.error(traceback.format_exc())
 
             TSHPlayerDB.signals.db_updated.emit()
 
@@ -188,7 +189,7 @@ class TSHPlayerDB:
 
                         spamwriter.writerow(playerData)
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
 
 TSHGameAssetManager.instance.signals.onLoad.connect(TSHPlayerDB.SetupModel)

--- a/src/TSHPlayerListSlotWidget.py
+++ b/src/TSHPlayerListSlotWidget.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import *
 from qtpy import uic
 import json
 import traceback
+from loguru import logger
 
 from .TSHScoreboardPlayerWidget import TSHScoreboardPlayerWidget
 from .Helpers.TSHCountryHelper import TSHCountryHelper
@@ -109,7 +110,7 @@ class TSHPlayerListSlotWidget(QGroupBox):
                     pw.SetData(data.get("players")[i])
                 except:
                     pw.Clear()
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
             else:
                 pw.Clear()
         StateManager.ReleaseSaving()

--- a/src/TSHPlayerListWidget.py
+++ b/src/TSHPlayerListWidget.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import *
 from qtpy import uic
 import json
 import traceback
+from loguru import logger
 from .TSHPlayerListSlotWidget import TSHPlayerListSlotWidget
 
 from .TSHScoreboardPlayerWidget import TSHScoreboardPlayerWidget
@@ -112,5 +113,5 @@ class TSHPlayerListWidget(QDockWidget):
                     slot.SetTeamData(data[i])
                 except:
                     slot.Clear()
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
         StateManager.ReleaseSaving()

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -18,6 +18,7 @@ import time
 import math
 import random
 from .Helpers.TSHBadWordFilter import TSHBadWordFilter
+from loguru import logger
 
 
 class TSHScoreboardPlayerWidgetSignals(QObject):
@@ -155,8 +156,8 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                         if processed_line and processed_line not in self.pronoun_list:
                             self.pronoun_list.append(processed_line)
             except Exception as e:
-                print(f"ERROR: Did not find {file}")
-                print(traceback.format_exc())
+                logger.error(f"ERROR: Did not find {file}")
+                logger.error(traceback.format_exc())
         self.pronoun_model = QStringListModel()
         self.pronoun_completer.setModel(self.pronoun_model)
         self.pronoun_model.setStringList(self.pronoun_list)
@@ -292,7 +293,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
 
     def SwapWith(self, other: "TSHScoreboardPlayerWidget"):
         if self == other:
-            print("Swapping player with themselves")
+            logger.info("Swapping player with themselves")
             return
         try:
             StateManager.BlockSaving()
@@ -493,7 +494,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             state.lineEdit().setFont(QFont(state.font().family(), 9))
 
         except Exception as e:
-            print(e)
+            logger.error(e)
             exit()
 
     def LoadStates(self, index):

--- a/src/TSHScoreboardStageWidget.py
+++ b/src/TSHScoreboardStageWidget.py
@@ -13,10 +13,7 @@ from .StateManager import StateManager
 from .TSHWebServer import WebServer
 from .TSHGameAssetManager import TSHGameAssetManager
 import socket
-import logging
-
-log = logging.getLogger('werkzeug')
-log.setLevel(logging.ERROR)
+from loguru import logger
 
 
 class TSHScoreboardStageWidgetSignals(QObject):
@@ -274,7 +271,7 @@ class TSHScoreboardStageWidget(QDockWidget):
             with open("./user_data/rulesets.json", 'w', encoding="utf-8") as outfile:
                 json.dump(self.userRulesets, outfile, indent=4, sort_keys=True)
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         self.LoadRulesets()
         self.UpdateBottomButtons()
@@ -326,7 +323,7 @@ class TSHScoreboardStageWidget(QDockWidget):
                     rulesetsModel.appendRow(item)
         except:
             self.userRulesets = []
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         # Load startgg rulesets
         for ruleset in self.startggRulesets:
@@ -433,7 +430,7 @@ class TSHScoreboardStageWidget(QDockWidget):
             self.ValidateRuleset(ruleset)
             StateManager.Set(f"score.ruleset", vars(ruleset))
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
     def ValidateRuleset(self, ruleset: Ruleset):
         issues = []
@@ -506,7 +503,7 @@ class TSHScoreboardStageWidget(QDockWidget):
                 ruleset.banByMaxGames = {}
                 ruleset.errors.append(QApplication.translate(
                     "app", "The text for banByMaxGames is invalid."))
-                traceback.print_exc()
+                logger.error(traceback.format_exc())
 
         ruleset.strikeOrder = [
             int(n.strip()) for n in (self.strikeOrder.text().split(",") if self.strikeOrder.text() != "" else "1,2,1".split(",")) if n.strip() != ""
@@ -527,23 +524,23 @@ class TSHScoreboardStageWidget(QDockWidget):
                         open('./assets/rulesets.json',
                              'w').write(json.dumps(rulesets))
                         self.parent().startggRulesets = rulesets
-                        print("startgg Rulesets downloaded from startgg")
+                        logger.info("startgg Rulesets downloaded from startgg")
                         self.parent().signals.rulesets_changed.emit()
                     except:
-                        print(traceback.format_exc())
+                        logger.error(traceback.format_exc())
 
                         try:
                             rulesets = json.loads(
                                 open('./assets/rulesets.json').read())
                             self.parent().startggRulesets = rulesets
-                            print("startgg Rulesets loaded from local file")
+                            logger.info("startgg Rulesets loaded from local file")
                             self.parent().signals.rulesets_changed.emit()
                         except:
-                            print(traceback.format_exc())
+                            logger.error(traceback.format_exc())
             downloadThread = DownloadThread(self)
             downloadThread.start()
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         # https://www.start.gg/api/-/gg_api./rulesets
         # entities > ruleset[]

--- a/src/TSHSelectSetWindow.py
+++ b/src/TSHSelectSetWindow.py
@@ -2,6 +2,7 @@ import traceback
 from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 from qtpy.QtCore import *
+from loguru import logger
 
 from src.TSHTournamentDataProvider import TSHTournamentDataProvider
 
@@ -87,7 +88,7 @@ class TSHSelectSetWindow(QDialog):
             showFinished=self.showFinished.isChecked())
 
     def SetSets(self, sets):
-        print("Got sets", len(sets))
+        logger.info("Got sets" + len(sets))
         model = QStandardItemModel()
         horizontal_labels = ["Stream", "Wave", "Title", "Player 1", "Player 2"]
         horizontal_labels[0] = QApplication.translate("app", "Stream")
@@ -119,7 +120,7 @@ class TSHSelectSetWindow(QDialog):
                             player_names[t] += " "+QApplication.translate(
                                 "punctuation", "(")+", ".join(pnames)+QApplication.translate("punctuation", ")")
                 except Exception as e:
-                    traceback.print_exc()
+                    logger.error(traceback.format_exc())
 
                 model.appendRow([
                     QStandardItem(s.get("stream", "")),

--- a/src/TSHSelectSetWindow.py
+++ b/src/TSHSelectSetWindow.py
@@ -88,7 +88,7 @@ class TSHSelectSetWindow(QDialog):
             showFinished=self.showFinished.isChecked())
 
     def SetSets(self, sets):
-        logger.info("Got sets" + len(sets))
+        logger.info("Got sets" + str(len(sets)))
         model = QStandardItemModel()
         horizontal_labels = ["Stream", "Wave", "Title", "Player 1", "Player 2"]
         horizontal_labels[0] = QApplication.translate("app", "Stream")

--- a/src/TSHStageStrikeLogic.py
+++ b/src/TSHStageStrikeLogic.py
@@ -1,5 +1,6 @@
 from .StateManager import StateManager
 from copy import deepcopy
+from loguru import logger
 
 class TSHStageStrikeState:
     def __init__(self) -> None:
@@ -79,7 +80,7 @@ class TSHStageStrikeLogic():
         self.Initialize()
     
     def Initialize(self, resetStreamScore = False):
-        print("Stage Strike Logic Initialize")
+        logger.info("Stage Strike Logic Initialize")
         self.AddHistory(TSHStageStrikeState())
         self.ExportState()
     
@@ -87,7 +88,7 @@ class TSHStageStrikeLogic():
         return self.history[self.historyIndex]
     
     def RpsResult(self, player):
-        print("RPS won by", player)
+        logger.info("RPS won by", player)
         newState = self.CurrentState().Clone()
         newState.lastWinner = player
         newState.currPlayer = player
@@ -136,14 +137,14 @@ class TSHStageStrikeLogic():
                 return 0
 
     def StageClicked(self, stage):
-        print("Clicked on stage", stage.get("codename"))
+        logger.info("Clicked on stage", stage.get("codename"))
 
         if (self.CurrentState().currGame > 0 and self.CurrentState().currStep > 0) or self.CurrentState().gentlemans:
             # we're picking
             if (not self.IsStageBanned(stage.get("codename")) and not self.IsStageStriked(stage.get("codename"))) or self.CurrentState().gentlemans:
                 newState = self.CurrentState().Clone()
                 newState.selectedStage = stage.get("codename")
-                print("Stage picked")
+                logger.info("Stage picked")
                 self.AddHistory(newState)
         elif not self.IsStageStriked(stage.get("codename"), True) and not self.IsStageBanned(stage.get("codename")):
             # we're banning
@@ -151,13 +152,13 @@ class TSHStageStrikeLogic():
             
             if foundIndex == None:
                 if len(self.CurrentState().strikedStages[self.CurrentState().currStep]) < self.GetStrikeNumber():
-                    print("Stage banned")
+                    logger.info("Stage banned")
                     newState = self.CurrentState().Clone()
                     newState.strikedStages[newState.currStep].append(stage.get("codename"));
                     newState.strikedBy[newState.currPlayer].append(stage.get("codename"));
                     self.AddHistory(newState)
             else:
-                print("Stage unbanned")
+                logger.info("Stage unbanned")
 
                 newState = self.CurrentState().Clone()
                 newState.strikedStages[newState.currStep].pop(foundIndex)
@@ -220,7 +221,7 @@ class TSHStageStrikeLogic():
             self.ConfirmClicked(justOverwrite=True)
     
     def SetGentlemans(self, value):
-        print(f"Setting gentlemans to {value}")
+        logger.info(f"Setting gentlemans to {value}")
         newState = self.CurrentState().Clone()
 
         newState.gentlemans = value

--- a/src/TSHStageStrikeLogic.py
+++ b/src/TSHStageStrikeLogic.py
@@ -88,7 +88,7 @@ class TSHStageStrikeLogic():
         return self.history[self.historyIndex]
     
     def RpsResult(self, player):
-        logger.info("RPS won by", player)
+        logger.info("RPS won by " + str(player+1))
         newState = self.CurrentState().Clone()
         newState.lastWinner = player
         newState.currPlayer = player
@@ -137,7 +137,7 @@ class TSHStageStrikeLogic():
                 return 0
 
     def StageClicked(self, stage):
-        logger.info("Clicked on stage", stage.get("codename"))
+        logger.info("Clicked on stage " + stage.get("codename"))
 
         if (self.CurrentState().currGame > 0 and self.CurrentState().currStep > 0) or self.CurrentState().gentlemans:
             # we're picking

--- a/src/TSHStatsUtil.py
+++ b/src/TSHStatsUtil.py
@@ -6,6 +6,7 @@ import math
 from .StateManager import *
 from .SettingsManager import *
 from .TSHTournamentDataProvider import TSHTournamentDataProvider
+from loguru import logger
 
 
 class TSHStatsSignals(QObject):
@@ -154,10 +155,10 @@ class TSHStatsUtil:
                 p1 = StateManager.Get(f"score.team.1.player.1.seed")
                 p2 = StateManager.Get(f"score.team.2.player.1.seed")
                 if p1 and p2:
-                    print("P1 Seed: " + str(p1))
+                    logger.info("P1 Seed: " + str(p1))
                     p1_upset = self.CalculatePlacementMath(bracket_type, p1)
 
-                    print("P2 Seed: " + str(p2))
+                    logger.info("P2 Seed: " + str(p2))
                     p2_upset = self.CalculatePlacementMath(bracket_type, p2)
 
                     StateManager.Set(f"score.upset_factor",

--- a/src/TSHThumbnailSettingsWidget.py
+++ b/src/TSHThumbnailSettingsWidget.py
@@ -7,6 +7,7 @@ from qtpy import uic
 from pathlib import Path
 import sys
 import os
+from loguru import logger
 
 from .thumbnail import main_generate_thumbnail as thumbnail
 from .SettingsManager import *
@@ -172,7 +173,7 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                 config["filename"] = t
                 self.templates.append(config)
             except Exception as e:
-                print(e)
+                logger.error(e)
 
         for t in self.templates:
             self.templateSelect.addItem(
@@ -530,7 +531,7 @@ class TSHThumbnailSettingsWidget(QDockWidget):
         try:
             self.preview.setPixmap(QPixmap(tmp_file))
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         self.updateFromSettings()
 
@@ -558,7 +559,7 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                     self.templateSelect.setCurrentIndex(i)
                     self.templateSelect.blockSignals(False)
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         # Upper checkboxes
         self.phase_name.blockSignals(True)
@@ -810,8 +811,8 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                 self.SaveSettings(f"{key}", val=fontSetting)
                 self.GeneratePreview()
         except Exception as e:
-            print("error save font")
-            print(e)
+            logger.error("Error saving font")
+            logger.error(e)
 
     def ColorPicker(self, button, key):
         try:
@@ -822,19 +823,19 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                 self.SaveSettings(f"{key}", val=color)
                 self.updateFromSettings()
         except Exception as e:
-            print(e)
+            logger.error(e)
 
     def SaveSettings(self, key, val, generatePreview=False):
         try:
             SettingsManager.Set(f"thumbnail_config.{key}", val)
         except Exception as e:
-            print(e)
+            logger.error(e)
 
         if generatePreview:
             self.GeneratePreview()
 
     def SetTypeFont(self, index, cbFont, cbType):
-        print(f'set type font {cbFont.currentData()}')
+        logger.info(f'set type font {cbFont.currentData()}')
         types = ["Regular", "Bold", "Italic", "Bold Italic"]
         types_localised = ["Regular", "Bold", "Italic", "Bold Italic"]
         types_localised[0] = QApplication.translate("app", "Regular")
@@ -921,7 +922,7 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                 pass
 
     def DisplayErrorMessage(self, e):
-        print(e)
+        logger.error(e)
         msgBox = QMessageBox()
         msgBox.setWindowIcon(QIcon('assets/icons/icon.png'))
         msgBox.setWindowTitle(QApplication.translate(

--- a/src/TSHTournamentDataProvider.py
+++ b/src/TSHTournamentDataProvider.py
@@ -12,6 +12,7 @@ from .TournamentDataProvider.TournamentDataProvider import TournamentDataProvide
 from .TournamentDataProvider.ChallongeDataProvider import ChallongeDataProvider
 from .TournamentDataProvider.StartGGDataProvider import StartGGDataProvider
 import json
+from loguru import logger
 
 from .Workers import Worker
 
@@ -57,7 +58,7 @@ class TSHTournamentDataProvider:
             TSHGameAssetManager.instance.SetGameFromChallongeId(
                 self.provider.videogame)
         else:
-            print("Unsupported provider...")
+            logger.error("Unsupported provider...")
 
     def SetTournament(self, url, initialLoading=False):
         if self.provider and self.provider.url == url:
@@ -70,7 +71,7 @@ class TSHTournamentDataProvider:
             TSHTournamentDataProvider.instance.provider = ChallongeDataProvider(
                 url, self.threadPool, self)
         else:
-            print("Unsupported provider...")
+            logger.error("Unsupported provider...")
             TSHTournamentDataProvider.instance.provider = None
 
         SettingsManager.Set("TOURNAMENT_URL", url)
@@ -170,7 +171,7 @@ class TSHTournamentDataProvider:
                 "app", "Insert the player's name in bracket")
             providerName = self.provider.name
         else:
-            print(QApplication.translate(
+            logger.error(QApplication.translate(
                 "app", "Invalid tournament data provider"))
             return
 
@@ -210,7 +211,7 @@ class TSHTournamentDataProvider:
         worker = Worker(self.provider.GetMatches, **
                         {"getFinished": showFinished})
         worker.signals.result.connect(lambda data: [
-            print(data),
+            logger.info(data),
             self.signals.get_sets_finished.emit(data)
         ])
         self.threadPool.start(worker)

--- a/src/TSHTournamentInfoWidget.py
+++ b/src/TSHTournamentInfoWidget.py
@@ -15,6 +15,7 @@ import traceback
 import os
 import shutil
 import urllib
+from loguru import logger
 
 
 class TSHTournamentInfoWidget(QDockWidget):
@@ -108,7 +109,7 @@ class TSHTournamentInfoWidget(QDockWidget):
                 pix = QPixmap(fileName)
                 pix.save("./layout/logo.png")
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         self.UpdateIcon()
 
@@ -124,7 +125,7 @@ class TSHTournamentInfoWidget(QDockWidget):
 
             pix.save("./layout/logo.png")
         except Exception as e:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         self.UpdateIcon()
 
@@ -132,7 +133,7 @@ class TSHTournamentInfoWidget(QDockWidget):
         try:
             shutil.copy("./assets/icons/icon.png", "./layout/logo.png")
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         self.UpdateIcon()
 
@@ -146,7 +147,7 @@ class TSHTournamentInfoWidget(QDockWidget):
         msgBox.exec()
 
     def UpdateData(self, data):
-        print("tournamentdata", data)
+        logger.info("Tournament Data: "+ str(data))
 
         if not data.get("initial_load"):
             for widget in self.findChildren(QLineEdit):
@@ -181,7 +182,7 @@ class TSHTournamentInfoWidget(QDockWidget):
                         d = QDate.fromString(local_date, "yyyy-MM-dd")
                         widget.setDate(d)
             except:
-                print(traceback.format_exc())
+                logger.error(traceback.format_exc())
                 SettingsManager.Set("TOURNAMENT_URL", '')
                 error_message = QApplication.translate("app", "The tournament URL could not be loaded.") + "\n" + QApplication.translate(
                     "app", "Make sure that your tournament URL is correctly formatted and points to an existing event, and try again.")

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -9,6 +9,7 @@ from .StateManager import StateManager
 from .TSHStatsUtil import TSHStatsUtil
 from .TSHTournamentDataProvider import TSHTournamentDataProvider
 from .SettingsManager import SettingsManager
+from loguru import logger
 
 
 class WebServer(QThread):
@@ -109,7 +110,7 @@ class WebServer(QThread):
         return "OK"
 
     def UpdateScore():
-        print(SettingsManager.Get("general.control_score_from_stage_strike", True), SettingsManager.Get("general.control_score_from_stage_strike", 12))
+        logger.info(SettingsManager.Get("general.control_score_from_stage_strike", True), SettingsManager.Get("general.control_score_from_stage_strike", 12))
 
         if not SettingsManager.Get("general.control_score_from_stage_strike", True):
             return
@@ -258,7 +259,7 @@ class WebServer(QThread):
             TSHStatsUtil.instance.signals.LastSetsP1Signal.emit()
             TSHStatsUtil.instance.signals.LastSetsP2Signal.emit()
         else:
-            print("[Last Sets] Unable to find player defined. Allowed values are: 1, 2, or both")
+            logger.error("[Last Sets] Unable to find player defined. Allowed values are: 1, 2, or both")
         return "OK"
 
    # Resubmits Call for History Sets
@@ -272,7 +273,7 @@ class WebServer(QThread):
             TSHStatsUtil.instance.signals.PlayerHistoryStandingsP1Signal.emit()
             TSHStatsUtil.instance.signals.PlayerHistoryStandingsP2Signal.emit()
         else:
-            print("[History Standings] Unable to find player defined. Allowed values are: 1, 2, or both")
+            logger.error("[History Standings] Unable to find player defined. Allowed values are: 1, 2, or both")
         return "OK"
 
     # Resets scores

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -11,6 +11,10 @@ from .TSHTournamentDataProvider import TSHTournamentDataProvider
 from .SettingsManager import SettingsManager
 from loguru import logger
 
+import logging
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
 
 class WebServer(QThread):
     app = Flask(__name__, static_folder=os.path.curdir)
@@ -110,7 +114,6 @@ class WebServer(QThread):
         return "OK"
 
     def UpdateScore():
-        logger.info(SettingsManager.Get("general.control_score_from_stage_strike", True), SettingsManager.Get("general.control_score_from_stage_strike", 12))
 
         if not SettingsManager.Get("general.control_score_from_stage_strike", True):
             return

--- a/src/TournamentDataProvider/ChallongeDataProvider.py
+++ b/src/TournamentDataProvider/ChallongeDataProvider.py
@@ -20,6 +20,7 @@ from ..TSHBracket import next_power_of_2
 import math
 import random
 import cloudscraper
+from loguru import logger
 
 HEADERS = {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
@@ -49,7 +50,7 @@ class ChallongeDataProvider(TournamentDataProvider):
         i, initialized = 0, False
         while not initialized and i < max_iter:
             if i > 0:
-                print(f"Retrying Cloudfare initialization (Attempt #{i+1})")
+                logger.info(f"Retrying Cloudfare initialization (Attempt #{i+1})")
             try:
                 self.scraper = cloudscraper.create_scraper(browser={
                     'browser': 'firefox',
@@ -123,7 +124,7 @@ class ChallongeDataProvider(TournamentDataProvider):
                     timestamp = datetime.timestamp(element)
                     finalData["startAt"] = datetime.timestamp(element)
                 except ValueError:
-                    print('ChallongeDataProvider: No date defined')
+                    logger.error('ChallongeDataProvider: No date defined')
 
             details = collection.get("details", [])
             participantsElement = next(
@@ -135,7 +136,7 @@ class ChallongeDataProvider(TournamentDataProvider):
             # finalData["address"] = deep_get(
             #     data, "data.event.tournament.venueAddress", "")
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return finalData
 
@@ -158,7 +159,7 @@ class ChallongeDataProvider(TournamentDataProvider):
             if url.startswith("//"):
                 url = "https:" + url
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return url
 
@@ -180,7 +181,7 @@ class ChallongeDataProvider(TournamentDataProvider):
             if match:
                 finalData = self.ParseMatchData(match)
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return finalData
 
@@ -193,8 +194,8 @@ class ChallongeDataProvider(TournamentDataProvider):
                 headers=HEADERS,
                 allow_redirects=True
             )
-            print(self.GetEnglishUrl()+".json")
-            print(data.text)
+            logger.info(self.GetEnglishUrl()+".json")
+            logger.info(str(data.text))
             data = json.loads(data.text)
 
             all_matches = self.GetAllMatchesFromData(data)
@@ -212,7 +213,7 @@ class ChallongeDataProvider(TournamentDataProvider):
 
             final_data.reverse()
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return final_data
 
@@ -254,7 +255,7 @@ class ChallongeDataProvider(TournamentDataProvider):
                 ]
             })
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return phases
 
@@ -436,7 +437,7 @@ class ChallongeDataProvider(TournamentDataProvider):
             losersRoundKeys.sort(key=lambda x: int(x), reverse=False)
 
             if len(losersRoundKeys) % 2 == 1:
-                print(lr1ReverseMap)
+                logger.info(str(lr1ReverseMap))
 
                 for i, s in enumerate(rounds[int(losersRoundKeys[-2])]):
                     if len(lr1ReverseMap) > i and lr1ReverseMap[i] == True:
@@ -472,7 +473,7 @@ class ChallongeDataProvider(TournamentDataProvider):
 
             finalData["sets"] = rounds
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return finalData
 
@@ -672,7 +673,7 @@ class ChallongeDataProvider(TournamentDataProvider):
 
             TSHPlayerDB.AddPlayers(players)
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
     def ParseEntrant(self, data):
         # Here we're only supporting a single player per entrant
@@ -763,7 +764,7 @@ class ChallongeDataProvider(TournamentDataProvider):
 
             return final_data
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
     def GetLastSets(self, playerID, playerNumber, callback, progress_callback):
         try:
@@ -817,5 +818,5 @@ class ChallongeDataProvider(TournamentDataProvider):
             callback.emit(
                 {"playerNumber": playerNumber, "last_sets": set_data})
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             callback.emit({"playerNumber": playerNumber, "last_sets": []})

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -6,6 +6,7 @@ from qtpy.QtGui import QStandardItem, QStandardItemModel
 import requests
 import os
 import traceback
+from loguru import logger
 from ..Helpers.TSHCountryHelper import TSHCountryHelper
 from ..Helpers.TSHDictHelper import deep_get
 from ..TSHGameAssetManager import TSHGameAssetManager
@@ -81,7 +82,7 @@ class StartGGDataProvider(TournamentDataProvider):
             finalData["startAt"] = deep_get(
                 data, "data.event.tournament.startAt", "")
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return finalData
 
@@ -121,7 +122,7 @@ class StartGGDataProvider(TournamentDataProvider):
             if len(images) > 0:
                 url = images[0]["url"]
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return url
 
@@ -146,7 +147,7 @@ class StartGGDataProvider(TournamentDataProvider):
             )
 
             data = json.loads(data.text)
-            print(data)
+            logger.info(data)
 
             for phase in deep_get(data, "data.event.phases", []):
                 phaseObj = {
@@ -164,7 +165,7 @@ class StartGGDataProvider(TournamentDataProvider):
 
                 phases.append(phaseObj)
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return phases
 
@@ -244,7 +245,7 @@ class StartGGDataProvider(TournamentDataProvider):
             finalSets = {}
 
             for s in sets:
-                print(s)
+                logger.info(s)
 
                 round = int(s.get("round"))
 
@@ -310,7 +311,7 @@ class StartGGDataProvider(TournamentDataProvider):
                     gfsReset = finalData["sets"][str(lastRound)].pop()
                     finalData["sets"][str(lastRound+1)] = [gfsReset]
         except:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return finalData
 
@@ -358,7 +359,7 @@ class StartGGDataProvider(TournamentDataProvider):
                             finalResult["has_selection_data"] = True
 
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
         return finalResult
 
     def _GetMatchTasks(self, setId, progress_callback):
@@ -399,7 +400,7 @@ class StartGGDataProvider(TournamentDataProvider):
 
     def GetMatches(self, getFinished=False, progress_callback=None):
         try:
-            print("Get matches", getFinished)
+            logger.info("Get matches", getFinished)
             states = [1, 6, 2]
 
             if getFinished:
@@ -410,7 +411,7 @@ class StartGGDataProvider(TournamentDataProvider):
             page = 1
             totalPages = 1
 
-            print("Fetching sets")
+            logger.info("Fetching sets")
 
             while page <= totalPages:
                 data = requests.post(
@@ -445,11 +446,11 @@ class StartGGDataProvider(TournamentDataProvider):
 
                 page += 1
 
-                print(f"Fetching sets... {page}/{totalPages}")
+                logger.info(f"Fetching sets... {page}/{totalPages}")
 
             return (final_data)
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             return (final_data)
         return ([])
 
@@ -481,7 +482,7 @@ class StartGGDataProvider(TournamentDataProvider):
             elif name.startswith("Round "):
                 return TSHLocaleHelper.matchNames.get("round").format(roundNumber)
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
         return name
 
@@ -647,7 +648,7 @@ class StartGGDataProvider(TournamentDataProvider):
                     if len(selectedCharMap) > 0:
                         break
 
-        print(selectedCharMap)
+        logger.info(selectedCharMap)
         selectedChars = [[], []]
 
         for char in selectedCharMap.items():
@@ -824,7 +825,7 @@ class StartGGDataProvider(TournamentDataProvider):
                 "useMDSR": mdsr,
             }
         except:
-            print("No Stage Strike Info Found")
+            logger.info("No Stage Strike Info Found")
             allStages = None
             strikedStages = None
             strikedBy = [[], []]
@@ -883,7 +884,7 @@ class StartGGDataProvider(TournamentDataProvider):
                 }
             )
             data = json.loads(data.text)
-            print("Stream queue loaded from StartGG")
+            logger.info("Stream queue loaded from StartGG")
 
             eventSlug = deep_get(data, "data.event.slug", "")
             queues = deep_get(data, "data.event.tournament.streamQueue", [])
@@ -891,7 +892,7 @@ class StartGGDataProvider(TournamentDataProvider):
             finalData = {}
 
             if not queues:
-                print("(No stream queue was found)")
+                logger.info("(No stream queue was found)")
                 return finalData
 
             for q in queues:
@@ -986,7 +987,7 @@ class StartGGDataProvider(TournamentDataProvider):
 
                 finalData[streamName] = queueData
 
-            print(finalData)
+            logger.info(finalData)
 
             return finalData
 
@@ -1002,7 +1003,7 @@ class StartGGDataProvider(TournamentDataProvider):
             """
 
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return {}
 
@@ -1044,21 +1045,21 @@ class StartGGDataProvider(TournamentDataProvider):
                     if len(queueSets) > 0:
                         streamSet = queueSets[0]
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return streamSet
 
     def GetUserMatchId(self, user):
         matches = re.match(
             r".*start.gg/(user/[^/]*)", user)
-        print(matches)
+        logger.info(matches)
         if matches:
             user = matches.groups()[0]
 
         userSet = None
 
         try:
-            print(user)
+            logger.info(user)
             data = requests.post(
                 "https://www.start.gg/api/-/gql",
                 headers={
@@ -1078,7 +1079,7 @@ class StartGGDataProvider(TournamentDataProvider):
             )
             data = json.loads(data.text)
 
-            print(data)
+            logger.info(data)
 
             sets = deep_get(data, "data.user.player.sets.nodes")
 
@@ -1102,7 +1103,7 @@ class StartGGDataProvider(TournamentDataProvider):
                 )
                 data = json.loads(data.text)
 
-                print(data)
+                logger.info(data)
 
                 sets = deep_get(data, "data.user.player.sets.nodes")
 
@@ -1125,9 +1126,9 @@ class StartGGDataProvider(TournamentDataProvider):
                             userSet["reverse"] = True
                             break
 
-                print(userSet)
+                logger.info(userSet)
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
         return userSet
 
@@ -1208,7 +1209,7 @@ class StartGGDataProvider(TournamentDataProvider):
             callback.emit(
                 {"playerNumber": playerNumber, "last_sets": set_data})
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             callback.emit({"playerNumber": playerNumber, "last_sets": []})
 
     def GetPlayerHistoryStandings(self, playerID, playerNumber, gameType, callback, progress_callback):
@@ -1250,7 +1251,7 @@ class StartGGDataProvider(TournamentDataProvider):
                     tournamentPicture = tournament.get("images")[0].get("url")
                 except:
                     tournamentPicture = None
-                    print(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
                 player_history = {
                     "placement": set.get("placement"),
@@ -1279,7 +1280,7 @@ class StartGGDataProvider(TournamentDataProvider):
 
             pool.clear()
 
-            print("Get recent sets start")
+            logger.info("Get recent sets start")
 
             for _id1, _id2, inverted in [[id1, id2, False], [id2, id1, True]]:
                 for i in range(5):
@@ -1299,10 +1300,10 @@ class StartGGDataProvider(TournamentDataProvider):
             byId = {_set.get("id"): _set for _set in recentSets}
             recentSets = list(byId.values())
             recentSets.sort(key=lambda s: s.get("timestamp"), reverse=True)
-            print("Recent sets size:", len(recentSets))
+            logger.info("Recent sets size:", len(recentSets))
             callback.emit({"sets": recentSets, "request_time": requestTime})
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             callback.emit({"sets": [], "request_time": requestTime})
 
     def GetRecentSetsWorker(self, id1, id2, page, inverted, progress_callback):
@@ -1414,7 +1415,7 @@ class StartGGDataProvider(TournamentDataProvider):
                     recentSets.append(entry)
             return recentSets
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             return []
 
     def GetEntrantsWorker(self, eventSlug, gameId, progress_callback):
@@ -1425,7 +1426,7 @@ class StartGGDataProvider(TournamentDataProvider):
             players = []
 
             while page <= totalPages:
-                print(page, "/", totalPages)
+                logger.info(str(page) + "/" + str(totalPages))
                 data = requests.post(
                     "https://www.start.gg/api/-/gql",
                     headers={
@@ -1450,7 +1451,7 @@ class StartGGDataProvider(TournamentDataProvider):
                     data, "data.event.entrants.pageInfo.totalPages", 0)
 
                 entrants = deep_get(data, "data.event.entrants.nodes", [])
-                print("Entrants: ", len(entrants))
+                logger.info("Entrants: " + str(len(entrants)))
 
                 for i, team in enumerate(entrants):
                     for j, entrant in enumerate(team.get("participants", [])):
@@ -1468,7 +1469,7 @@ class StartGGDataProvider(TournamentDataProvider):
 
                 page += 1
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
     def ProcessEntrantData(entrant, setData=[]):
         player = entrant.get("player")
@@ -1625,7 +1626,7 @@ class StartGGDataProvider(TournamentDataProvider):
                 teams.append(team)
             return (teams)
         except Exception as e:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
 
 
 f = open("src/TournamentDataProvider/StartGGSetsQuery.txt", 'r')

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -21,6 +21,7 @@ from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 from qtpy.QtCore import *
 from packaging.version import parse
+from loguru import logger
 
 QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 
@@ -28,7 +29,27 @@ if parse(qtpy.QT_VERSION).major == 6:
     QImageReader.setAllocationLimit(0)
 
 App = QApplication(sys.argv)
-print("QApplication successfully initialized")
+
+fmt = ("<green>{time:YYYY-MM-DD HH:mm:ss}</green> " +
+      "| <level>{level}</level> | " +
+      "<yellow>{file}</yellow>:<blue>{function}</blue>:<cyan>{line}</cyan> " +
+      "- <level>{message}</level>")
+config = {
+    "handlers": [
+        {"sink": sys.stdout, "format": fmt},
+    ],
+}
+logger.configure(**config)
+
+logger.add("./logs/log-{time:YYYY-MM-DD - HH.mm.ss}.log"
+           , format="[{time:YYYY-MM-DD HH:mm:ss}] - {level} - {file}:{function}:{line} | {message}"
+           , encoding="utf-8"
+           , level="INFO")
+logger.add("./logs/errors/error-{time:YYYY-MM-DD - HH.mm.ss}.log"
+           , format="[{time:YYYY-MM-DD HH:mm:ss}] - {level} - {file}:{function}:{line} | {message}"
+           , encoding="utf-8"
+           , level="ERROR")
+logger.info("QApplication successfully initialized")
 
 # autopep8: off
 from .Settings.TSHSettingsWindow import TSHSettingsWindow
@@ -48,10 +69,6 @@ from .TSHThumbnailSettingsWidget import *
 from src.TSHAssetDownloader import TSHAssetDownloader
 from src.TSHAboutWidget import TSHAboutWidget
 # autopep8: on
-
-if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-    sys.stderr = open('./assets/log_error.txt', 'w', encoding="utf-8")
-    sys.stdout = open('./assets/log.txt', 'w', encoding="utf-8")
 
 
 def generate_restart_messagebox(main_txt):
@@ -88,7 +105,7 @@ def UpdateProcedure():
         messagebox.exec()
     except Exception as e:
         # Layout folder backups failed
-        print(e)
+        logger.error(e)
 
         buttonReply = QDialog()
         buttonReply.setWindowTitle(
@@ -141,7 +158,7 @@ def ExtractUpdate():
         tar.close()
         os.remove("update.tar.gz")
     except Exception as e:
-        print(traceback.format_exc())
+        logger.error(traceback.format_exc())
 
 
 def remove_accents_lower(input_str):
@@ -638,7 +655,7 @@ class Window(QMainWindow):
             shutil.rmtree("./tmp")
 
     def ReloadGames(self):
-        print("Reload games")
+        logger.info("Reload games")
         self.gameSelect.setModel(QStandardItemModel())
         self.gameSelect.addItem("", 0)
         for i, game in enumerate(TSHGameAssetManager.instance.games.items()):
@@ -689,7 +706,7 @@ class Window(QMainWindow):
             versions = json.load(
                 open('./assets/versions.json', encoding='utf-8'))
         except Exception as e:
-            print("Local version file not found")
+            logger.error("Local version file not found")
 
         if versions and release:
             myVersion = versions.get("program", "0.0")
@@ -807,7 +824,7 @@ class Window(QMainWindow):
                 baseIcon = self.downloadAssetsAction.icon().pixmap(32, 32)
                 self.downloadAssetsAction.setIcon(QIcon(baseIcon))
         except:
-            print(traceback.format_exc())
+            logger.error(traceback.format_exc())
 
     def ToggleAlwaysOnTop(self, checked):
         if checked:

--- a/src/Workers.py
+++ b/src/Workers.py
@@ -3,6 +3,7 @@ from qtpy.QtWidgets import *
 from qtpy.QtCore import *
 import traceback
 import sys
+from loguru import logger
 
 class WorkerSignals(QObject):
     '''
@@ -65,8 +66,7 @@ class Worker(QRunnable):
         try:
             result = self.fn(*self.args, **self.kwargs)
         except Exception as e:
-            print(traceback.format_exc())
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             exctype, value = sys.exc_info()[:2]
             self.signals.error.emit((exctype, value, traceback.format_exc()))
         else:

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -14,6 +14,7 @@ import shutil
 import datetime
 import os
 import re
+from loguru import logger
 
 from src.TSHGameAssetManager import TSHGameAssetManager
 from src.Helpers.TSHLocaleHelper import TSHLocaleHelper
@@ -304,7 +305,7 @@ def paste_image_matrix(thumbnail, path_matrix, max_size, paste_coordinates, eyes
                     max_size[0], round(max_size[1]/num_line))
                 individual_paste_x = paste_coordinates[0]
 
-            print(f"Processing asset: {image_path}")
+            logger.info(f"Processing asset: {image_path}")
 
             pix = QPixmap(image_path, "RGBA")
             tmpWidth = int(pix.width() * image_ratio[0])
@@ -1280,10 +1281,10 @@ def generate(settingsManager, isPreview=False, gameAssetManager=None):
     ]
     # not blocking so empty
     if side_icon_list[0] and not os.path.isfile(side_icon_list[0]):
-        print(f"Top Left Icon {side_icon_list[0]} doesn't exist !")
+        logger.info(f"Top Left Icon {side_icon_list[0]} doesn't exist !")
         side_icon_list[0] = ''
     if side_icon_list[1] and not os.path.isfile(side_icon_list[1]):
-        print(f"Top Right Icon {side_icon_list[1]} doesn't exist !")
+        logger.info(f"Top Right Icon {side_icon_list[1]} doesn't exist !")
         side_icon_list[1] = ''
     # BOOLEAN
     display_phase = deep_get(settings, f"display_phase")
@@ -1482,12 +1483,12 @@ def generate(settingsManager, isPreview=False, gameAssetManager=None):
         thumbnail.save(f"{out_path}/{thumbnail_filename}.jpg")
         if os.path.isdir(tmp_path):
             shutil.rmtree(tmp_path)
-        print(
+        logger.info(
             f"Thumbnail successfully saved as {out_path}/{thumbnail_filename}.png and {out_path}/{thumbnail_filename}.jpg")
         return f"{out_path}/{thumbnail_filename}.png"
     else:
         thumbnail_filename = f"template"
         thumbnail.save(f"{out_path}/{thumbnail_filename}.png")
-        print(
+        logger.info(
             f"Thumbnail successfully saved as {out_path}/{thumbnail_filename}.png")
         return f"{out_path}/{thumbnail_filename}.png"


### PR DESCRIPTION
Since I wanted to get this out of the way before starting the multi-stream capability, I have officially swapped over any logging and stack trace posting to a proper logger in TSH that not only makes it easier to notice errors when working in dev, but also to make our lives easier, I have separated out the logs into their own logs folder, with a subfolder for where the error logs are posted to help separate them out for people. I have added additional logging as well to post what file and function is being called with the logging to help track what certain files are doing what.

There are additional options with loguru logger that allow for X time of log retention and rotation, but just to make it simple, I left those out for now and we can look to enable/use that feature in the future.

Obviously this will need to be tested on Linux to make sure it works, as well as doing a test build with the EXE to make sure everything works there as well.