### PR TITLE
attempt to fix webapp being unable to change score

### DIFF
--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -778,15 +778,8 @@ class TSHScoreboardWidget(QDockWidget):
         self.team1column.findChild(QCheckBox, "losers").setChecked(False)
         self.team2column.findChild(QCheckBox, "losers").setChecked(False)
 
-    def UpdateSetData(self, data):
-        # Do not update the scoreboard on empty data
-        if data is None or len(data) == 0 or data.get("id") == None:
-            return
-
-        # If you switched sets and it was still finishing an async update call
-        # Avoid loading data from the previous set
-        if str(data.get("id")) != str(self.lastSetSelected):
-            return
+    # Modifies the current set data. Does not check for id, so do not call this with data that may lead to another hbox incident 
+    def ChangeSetData(self, data):
 
         StateManager.BlockSaving()
 
@@ -813,6 +806,8 @@ class TSHScoreboardWidget(QDockWidget):
             if data.get("reset_score"):
                 scoreContainers[0].setValue(0)
                 scoreContainers[1].setValue(0)
+
+            logger.info(data.get("team1score"))
 
             if data.get("team1score"):
                 scoreContainers[0].setValue(data.get("team1score"))
@@ -883,3 +878,15 @@ class TSHScoreboardWidget(QDockWidget):
                 TSHStatsUtil.instance.signals.UpsetFactorCalculation.emit()
         finally:
             StateManager.ReleaseSaving()
+
+    def UpdateSetData(self, data):
+        # Do not update the scoreboard on empty data
+        if data is None or len(data) == 0 or data.get("id") == None:
+            return
+
+        # If you switched sets and it was still finishing an async update call
+        # Avoid loading data from the previous set
+        if str(data.get("id")) != str(self.lastSetSelected):
+            return
+        
+        self.ChangeSetData(data)

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -115,6 +115,9 @@ class WebServer(QThread):
 
     def UpdateScore():
 
+        logger.info("================UPDATE SCORE !============")
+        logger.info(SettingsManager.Get("general.control_score_from_stage_strike"))
+
         if not SettingsManager.Get("general.control_score_from_stage_strike", True):
             return
 
@@ -123,7 +126,11 @@ class WebServer(QThread):
             len(WebServer.stageWidget.stageStrikeLogic.CurrentState().stagesWon[1]),
         ]
         
-        WebServer.scoreboard.signals.UpdateSetData.emit({
+        logger.info("La on est suppose update le score")
+        print(score)
+        print(score[0])
+
+        WebServer.scoreboard.ChangeSetData({
             "team1score": score[0],
             "team2score": score[1],
             "reset_score": True


### PR DESCRIPTION
Trying to fix #522 : now that the UpdateSetData has been updated and works only when provided a full set data (with a set id), the web app should not use this method, but rather a method that just updates the provided data without checking if it's "complete". 

I created a new method that just changes the score, and the web server calls it now.