### PR TITLE
Fix macOS compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ assets/log_error.txt
 layout_backup*
 layout_custom*
 .idea/
+.DS_Store
 
 TSH.cflags
 

--- a/TSH.sh
+++ b/TSH.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install -r dependencies/requirements.txt
+python3 -m pip install -r dependencies/requirements.txt
 python3 main.py

--- a/src/TSHHotkeys.py
+++ b/src/TSHHotkeys.py
@@ -5,6 +5,7 @@ from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 import requests
 import os
+import platform
 import traceback
 import json
 import copy
@@ -67,6 +68,10 @@ class TSHHotkeys(QObject):
                 shortcuts[pynputShortcut] = lambda key=key, value=value: self.HotkeyTriggered(key, value)
         
         self.pynputListener = pynput.keyboard.GlobalHotKeys(shortcuts)
+
+        if platform.system() == "Darwin":
+            logger.error("macOS detected, deactivating hotkeys for now")
+            return
 
         self.pynputListener.start()
     


### PR DESCRIPTION
When running on macOS, hotkeys listener fails to start and makes the app crash.

I also took the liberty to "fix" the main script since `pip` might be pointing to another Python version (it was the case on my setup).

I can split those into two separate pull requests if you prefer.