### PR TITLE
Change Info icon to NoIcon

### DIFF
--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -440,7 +440,7 @@ class TSHScoreboardWidget(QDockWidget):
             thumbnailPath = thumbnail.generate(settingsManager=SettingsManager)
             msgBox.setText(QApplication.translate(
                 "thumb_app", "The thumbnail has been generated here:") + " ")
-            msgBox.setIcon(QMessageBox.Information)
+            msgBox.setIcon(QMessageBox.NoIcon)
             msgBox.setInformativeText(thumbnailPath)
 
             thumbnail_settings = SettingsManager.Get("thumbnail_config")


### PR DESCRIPTION
This will fix the sound request with the thumbnail generator. Unfortunately it comes at the cost of no icon being shown on the message box, but fixing it further would require touching QT accessibility settings, so maybe we can return to it later on.