### PR TITLE
Scoreboard Manager Initializing create the first scoreboard and translation fix

### DIFF
--- a/src/TSHScoreboardManager.py
+++ b/src/TSHScoreboardManager.py
@@ -16,12 +16,11 @@ class TSHScoreboardManager(QDockWidget):
     def __init__(self, *args):
         super().__init__(*args)
         
-        StateManager.Unset("score")
+        #StateManager.Unset("score")
 
         self.signals: TSHScoreboardManagerSignals = TSHScoreboardManagerSignals()
         logger.info("Scoreboard Manager - Initializing")
 
-        self.setWindowTitle(QApplication.translate("app", "Scoreboard Manager"))
         self.setFloating(True)
         self.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
         self.widget = QWidget()
@@ -36,6 +35,8 @@ class TSHScoreboardManager(QDockWidget):
         )
 
         self.scoreboardholder = []
+
+        self.UpdateAmount(1)
 
     def UpdateAmount(self, amount):
         if amount > len(self.scoreboardholder):
@@ -64,7 +65,11 @@ class TSHScoreboardManager(QDockWidget):
         
     def SetTabName(self, index, name):
         if int(index)-1 < self.tabs.count():
-            self.tabs.setTabText(int(index)-1, name)
+            if name != "":
+                self.tabs.setTabText(int(index)-1, name)
+            else:
+                self.tabs.setTabText(int(index)-1,
+                    QApplication.translate("app", "Scoreboard") + " " + str(index))
         else:
             logger.error(f"Invalid Scoreboard ID provided: {index}")
             logger.error(f"Please provide an ID between 1 and {len(self.tabs)}")

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -291,6 +291,7 @@ class Window(QMainWindow):
         self.addDockWidget(
             Qt.DockWidgetArea.BottomDockWidgetArea, self.scoreboard)
         self.dockWidgets.append(self.scoreboard)
+        TSHScoreboardManager.instance.setWindowTitle(QApplication.translate("app", "Scoreboard Manager"))
 
         self.stageWidget = TSHScoreboardStageWidget()
         self.stageWidget.setObjectName(
@@ -639,8 +640,6 @@ class Window(QMainWindow):
         hbox.addWidget(label)
         hbox.addWidget(self.scoreboardAmount)
         hbox.addWidget(self.btLoadModifyTabName)
-
-        TSHScoreboardManager.instance.UpdateAmount(1)
 
         self.CheckForUpdates(True)
         self.ReloadGames()


### PR DESCRIPTION
Addresses the Scoreboard Manager to automatically create the first scoreboard for the user over doing it on program init. Also addresses a weird translation issue with the scoreboard manager not properly applying when changing languages.