### PR TITLE
Undo initialization change for Scoreboard Manager to prevent a different issue

### DIFF
--- a/src/TSHScoreboardManager.py
+++ b/src/TSHScoreboardManager.py
@@ -36,8 +36,6 @@ class TSHScoreboardManager(QDockWidget):
 
         self.scoreboardholder = []
 
-        self.UpdateAmount(1)
-
     def UpdateAmount(self, amount):
         if amount > len(self.scoreboardholder):
             logger.info("Scoreboard Manager - Creating Scoreboard " + str(amount))

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -641,6 +641,8 @@ class Window(QMainWindow):
         hbox.addWidget(self.scoreboardAmount)
         hbox.addWidget(self.btLoadModifyTabName)
 
+        TSHScoreboardManager.instance.UpdateAmount(1)
+
         self.CheckForUpdates(True)
         self.ReloadGames()
 


### PR DESCRIPTION
This apparently caused the main scoreboard to not translate properly, so this addresses that.