### PR TITLE
Introduce potential fix to hide untranslated items

### DIFF
--- a/src/i18n/gen_translation_files.py
+++ b/src/i18n/gen_translation_files.py
@@ -37,6 +37,7 @@ for out_path in output:
         out = out_file.read()
     with open(out_path, "wt", encoding='utf-8') as out_file:
         out_file.write(out.replace(' type="vanished"', ""))
+        out_file.write(out.replace('<translation></translation>', '<translation type="vanished"></translation>'))
 
 with open("src/i18n/mapping.json", 'rt', encoding='utf-8') as mapping_file:
     mapping_data = json.loads(mapping_file.read())


### PR DESCRIPTION
This is in relation to #289 and Mathias seeing an issue where it was unvanishing all the untranslated items in the linguist files. In theory, this will now check to see if a blank translation exists, and if so, it'll add back the vanished tag to hide it as expected.