### PR TITLE
[WIP] Tracking individual games instead of just the score

### DIFF
--- a/assets/characters.json
+++ b/assets/characters.json
@@ -101850,6 +101850,84 @@
         ],
         "characterId": null,
         "expand": []
+      },
+      {
+        "id": 2343,
+        "name": "Infernal Host",
+        "isCommon": true,
+        "videogameId": 50435,
+        "externalIdMap": null,
+        "images": [
+          {
+            "id": 6178894,
+            "width": 200,
+            "height": 200,
+            "ratio": 1,
+            "type": "icon",
+            "url": "https://images.start.gg/images/character/2343/image-6a924acaeb55765597982b4ec8ccd965.png?ehk=KyucVEAHBGQP5a2ztmiwJdYNPibzdHsZN7CAP%2F9xbbk%3D&ehkOptimized=SYz7LncC0KR9aBqkyhXrrT8GJ3MQanXHNu%2Fds%2BXuUw8%3D",
+            "isOriginal": true,
+            "entity": null,
+            "entityId": null,
+            "uploadedBy": null,
+            "createdAt": null,
+            "updatedAt": null
+          },
+          {
+            "id": 6178895,
+            "width": 200,
+            "height": 200,
+            "ratio": 1,
+            "type": "stockIcon",
+            "url": "https://images.start.gg/images/character/2343/image-9f6c1cb933c0db19da4359a3f8ce0930.png?ehk=s2fnwZfmjY05T316FSX804IUQV4UuT6v3XEArsPCgj8%3D&ehkOptimized=aufF8XRx1GFtLA3GDkVvYwgBHfK4RYrQxzFHD01vukY%3D",
+            "isOriginal": true,
+            "entity": null,
+            "entityId": null,
+            "uploadedBy": null,
+            "createdAt": null,
+            "updatedAt": null
+          }
+        ],
+        "characterId": null,
+        "expand": []
+      },
+      {
+        "id": 2344,
+        "name": "Vanguard",
+        "isCommon": true,
+        "videogameId": 50435,
+        "externalIdMap": null,
+        "images": [
+          {
+            "id": 6178897,
+            "width": 200,
+            "height": 200,
+            "ratio": 1,
+            "type": "icon",
+            "url": "https://images.start.gg/images/character/2344/image-25052384ad79679f2614090e9d8bf563.png?ehk=%2F%2BioQFt2hk9bBf%2Bec8zcdJ6gprwve3tP%2B4BCKellD%2Bg%3D&ehkOptimized=FTfbnOmG%2FNV2VO%2BzguN6o6JNq5eSS0dLmVeqtbX4ikk%3D",
+            "isOriginal": true,
+            "entity": null,
+            "entityId": null,
+            "uploadedBy": null,
+            "createdAt": null,
+            "updatedAt": null
+          },
+          {
+            "id": 6178898,
+            "width": 200,
+            "height": 200,
+            "ratio": 1,
+            "type": "stockIcon",
+            "url": "https://images.start.gg/images/character/2344/image-5ac9babde33ca82b162acc980414927a.png?ehk=IxWnSuZHjKV22cSC%2F8mPC23vm0upJt1UvRB3Zzd28Vw%3D&ehkOptimized=oKpQD5e6L%2Fyw7ebpgHM2Zqd7%2FcYpsad7eJOVCLzTUR8%3D",
+            "isOriginal": true,
+            "entity": null,
+            "entityId": null,
+            "uploadedBy": null,
+            "createdAt": null,
+            "updatedAt": null
+          }
+        ],
+        "characterId": null,
+        "expand": []
       }
     ]
   },
@@ -103958,7 +104036,9 @@
     2339,
     2340,
     2341,
-    2342
+    2342,
+    2343,
+    2344
   ],
   "resultEntity": "character",
   "actionRecords": []

--- a/assets/contributors.txt
+++ b/assets/contributors.txt
@@ -5,8 +5,8 @@ JinchanJ
 Kekwel
 TwilCynder
 ladyisatis
-Lunki51
 ashleygruver
+Lunki51
 cash12121
 JuandePL
 Eric Iniguez

--- a/assets/rulesets.json
+++ b/assets/rulesets.json
@@ -1,1 +1,4996 @@
-[{"id": 2, "videogameId": 1, "name": "Full Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": null, "gameMode": null, "strikeOrder": null, "stages": {"neutral": [5, 11, 19, 20, 25], "counterpick": [15]}, "gameSetup": 1, "additionalFlags": {"disableBans": 3, "useMDSR": true}}, "eventSettings": null, "expand": []}, {"id": 3, "videogameId": 3, "name": null, "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [30, 34, 31, 37, 36], "counterpick": [38, 39]}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 4, "videogameId": 29, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": [1, 1], "stages": {"neutral": [158, 159, 160], "counterpick": [161, 162, 163, 164]}, "gameSetup": true, "banCount": null, "additionalFlags": {"banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 5, "videogameId": 7, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"doubleBlindOnly": true, "additionalFlags": [], "matchSetupOnly": true}, "eventSettings": null, "expand": []}, {"id": 6, "videogameId": 25, "name": "DO NOT USE", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"deckSetup": true, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 7, "videogameId": 26, "name": "Official Battlerite Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": {"1": [2, 2, 2, 1, 1, 1], "3": [2, 2, 1, 1, 1], "5": [2, 1, 1]}, "stages": {"neutral": [165, 166, 167, 168, 169, 170, 171, 172, 212, 213]}, "additionalFlags": {"maintainStrikes": true, "stageSelectAfterStrike": true, "disableBans": true, "firstStriker": 1, "individualCharBlind": true, "uniqueTeamCharacters": true, "blindBeforeAll": true, "characterSelectAfterStageSelect": true}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 8, "videogameId": 30, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": {"1": [1, 1, 1, 1, 1, 1], "3": [1, 1, 1, 1], "5": [1, 1]}, "stages": {"neutral": [193, 214, 215, 216, 217, 195, 218]}, "additionalFlags": {"maintainStrikes": true, "stageSelectAfterStrike": true, "disableBans": true, "ignoreCharacters": "blind_only", "stageSelectOverride": 2, "firstStriker": 2}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 9, "videogameId": 44087, "name": "Standard", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 205]}, "additionalFlags": {"selectFromAllStages": true, "maintainStrikes": true, "disableBans": true, "ignoreCharacters": true, "pickSideAfterMap": {"1": "Blue (Defend)", "2": "Red (Attack)"}}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 10, "videogameId": 31, "name": "Custom Overwatch", "description": "Map striking goes 1-1-1... etc.", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "stages": {"neutral": [173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 205]}, "additionalFlags": {"disableBans": true, "ignoreCharacters": true, "pickSideAfterMap": {"1": "Blue (Defend)", "2": "Red (Attack)"}, "stageSelectAfterStrike": true}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 11, "videogameId": 41, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"doubleBlindOnly": true, "additionalFlags": [], "matchSetupOnly": true}, "eventSettings": null, "expand": []}, {"id": 13, "videogameId": 40, "name": "Official For Honor Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"blindBeforeAll": true}}, "eventSettings": null, "expand": []}, {"id": 16, "videogameId": 3, "name": "Smash 4 Recommended Global Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [204, 34, 31, 37, 36]}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 17, "videogameId": 25, "name": "Blind Player Order", "description": "This ruleset has no deck selection but has a setup task for blindly choosing the order of players on each team", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"additionalFlags": {"doubleBlindOrder": true}, "matchSetupOnly": true}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": 1, "deckLimit": 2, "cardLimit": 8, "maxOverlap": 4, "minOverlapWithPrimary": null, "allowCharacterDupes": null, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 31, "videogameId": 25, "name": "Clash Royale", "description": "Official Clash Ruleset", "isDefault": null, "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": 2, "deckLimit": null, "cardLimit": 30, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": null, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 32, "videogameId": 13, "name": "Hearthstone", "description": "Hearthstone Ruleset", "isDefault": false, "gameMode": 1, "settings": {"deckRestrictions": {"legendaryLimit": 1}}, "eventSettings": null, "expand": []}, {"id": 33, "videogameId": 40, "name": "For Honor No Character Selection", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": [], "eventSettings": null, "expand": []}, {"id": 34, "videogameId": 88, "name": "Brawlout Standard", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": [1, 1, 1, 1], "stages": {"neutral": [208, 274, 247, 233, 496], "counterpick": [276, 246, 277], "strikeOrder": [1, 1, 1, 1]}, "additionalFlags": [], "gameSetup": true}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": 2, "deckLimit": null, "cardLimit": 30, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 35, "videogameId": 13, "name": "Conquest", "description": "Ruleset for Hearthstone conquest game mode.", "isDefault": false, "gameMode": 1, "settings": {"deckRestrictions": {"legendaryLimit": 1}, "gameSetup": true, "additionalFlags": {"classSelection": true, "deckDisableMode": "winners"}}, "eventSettings": {"classSelectionCount": {"label": "Class Count", "description": "Number of classes a user must select.", "isRequired": true, "defaultValue": 4, "component": "FormsyInputElement", "componentProps": {"type": "number"}}, "deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how users must display their decks.", "isRequired": true, "defaultValue": 2, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None - Class Selection Only", "value": 0}, {"name": "User Input", "value": 2}]}}, "includeClassBanStep": {"label": "Include Class Ban Step", "description": "Determines if a ban step is added to the start of the game.", "isRequired": true, "defaultValue": true, "component": "FormsyRadioElement", "componentProps": {"options": [{"name": "Yes", "description": "Add a class banning step to the start of a match. Number of classes required must exceed the number of wins required.", "value": true}, {"name": "No", "description": "Classes will not be banned.", "value": false}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 0, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}}, "expand": []}, {"type": "deck", "cardDupeLimit": 2, "deckLimit": null, "cardLimit": 30, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 36, "videogameId": 13, "name": "Last Hero Standing", "description": "Ruleset for Hearthstone last hero standing game mode.", "isDefault": false, "gameMode": 1, "settings": {"deckRestrictions": {"legendaryLimit": 1}, "gameSetup": true, "additionalFlags": {"classSelection": true, "deckDisableMode": "losers"}}, "eventSettings": {"classSelectionCount": {"label": "Class Count", "description": "Number of classes a user must select.", "isRequired": true, "defaultValue": 4, "component": "FormsyInputElement", "componentProps": {"type": "number"}}, "deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how users must display their decks.", "isRequired": true, "defaultValue": 2, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None - Class Selection Only", "value": 0}, {"name": "User Input", "value": 2}]}}, "includeClassBanStep": {"label": "Include Class Ban Step", "description": "Determines if a ban step is added to the start of the game.", "isRequired": true, "defaultValue": true, "component": "FormsyRadioElement", "componentProps": {"options": [{"name": "Yes", "description": "Add a class banning step to the start of a match. Number of classes required must exceed the number of wins required.", "value": true}, {"name": "No", "description": "Classes will not be banned.", "value": false}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 0, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}}, "expand": []}, {"id": 37, "videogameId": 40, "name": "Verification Test", "description": "UserMedia Verification Testing Ruleset", "isDefault": null, "type": "standard", "gameMode": 1, "settings": {"gameVerification": {"mediaType": "webpage", "contentType": "verification"}}, "eventSettings": null, "expand": []}, {"id": 38, "videogameId": 25, "name": "Clash Default", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": [], "eventSettings": null, "expand": []}, {"id": 41, "videogameId": 120, "name": "Pokemon Showdown 1v1 Ruleset", "description": "Requires URL replay uploads", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"gameVerification": {"mediaType": "webpage", "contentType": "verification"}}, "eventSettings": null, "expand": []}, {"id": 42, "videogameId": 1, "name": "Basic Tasks", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": [], "eventSettings": null, "expand": []}, {"id": 43, "videogameId": 35, "name": "Standard Injustice 2 Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 44, "videogameId": 3, "name": "Smash 4 Standard Ruleset", "description": "Current default ruleset for Smash 4", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [204, 34, 31, 37, 36]}, "gameSetup": 1, "additionalFlags": {"useMDSR": true}}, "eventSettings": null, "expand": []}, {"id": 45, "videogameId": 294, "name": "Form Ball", "description": "Default ruleset for Form Ball", "isDefault": true, "type": "standard", "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"id": 46, "videogameId": 294, "name": "Deathmatch (small)", "description": "Ruleset for 2-4 Players", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [221, 222, 223]}, "gameSetup": true, "additionalFlags": {"ignoreCharacters": true}, "strikeOrder": [1, 1]}, "eventSettings": null, "expand": []}, {"id": 47, "videogameId": 294, "name": "Deathmatch (medium)", "description": "Ruleset for 4-6 Players", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [224, 225, 221, 222, 223]}, "gameSetup": true, "additionalFlags": {"ignoreCharacters": true}}, "eventSettings": null, "expand": []}, {"id": 48, "videogameId": 294, "name": "Deathmatch (large)", "description": "Ruleset for 6-8 Players", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [226, 227, 228, 224, 225]}, "gameSetup": true, "additionalFlags": {"ignoreCharacters": true}}, "eventSettings": null, "expand": []}, {"id": 49, "videogameId": 562, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"doubleBlindOnly": true, "additionalFlags": [], "matchSetupOnly": true}, "eventSettings": null, "expand": []}, {"id": 51, "videogameId": 287, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"doubleBlindOnly": true, "additionalFlags": [], "characterSelectCount": 3, "gameSetup": true, "uniqueCharacters": true}, "eventSettings": null, "expand": []}, {"id": 52, "videogameId": 288, "name": null, "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"doubleBlindOnly": true, "additionalFlags": [], "characterSelectCount": 2, "gameSetup": true, "uniqueCharacters": true}, "eventSettings": null, "expand": []}, {"id": 53, "videogameId": 193, "name": "ARMS Standard", "description": "Old ARMS standard ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": [1, 2, 1], "stages": {"neutral": [258, 243, 239, 259, 244], "counterpick": [260, 241]}, "additionalFlags": {"stageSelectAfterStrike": true, "banCount": 2}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 54, "videogameId": 705, "name": "Tooth and Tail Standard", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": [], "eventSettings": null, "expand": []}, {"id": 55, "videogameId": 718, "name": "PUBG FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 56, "videogameId": 752, "name": "Quake Champions Standard", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": [], "eventSettings": null, "expand": []}, {"id": 57, "videogameId": 752, "name": "Quake Champions Sacrifice (4v4)", "description": "This is the Sacrifice (4v4) ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"characterSelectCount": 1, "gameSetup": true, "additionalFlags": {"individualCharBlind": false}}, "eventSettings": null, "expand": []}, {"id": 58, "videogameId": 865, "name": "Halo 5 Default", "description": "Halo 5 standard 4v4 ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"id": 59, "videogameId": 865, "name": "Halo 5 FFA", "description": "Halo 5 FFA ruleset", "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 60, "videogameId": 10, "name": "League Of Legends Standard Ruleset", "description": "This is the Standard League of Legends ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": [], "eventSettings": {"pickType": {"label": "Pick Type", "description": "Determine the pick type of the game", "isRequired": true, "defaultValue": "BLIND_PICK", "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Blind Pick", "value": "BLIND_PICK"}, {"name": "Draft Mode", "value": "DRAFT_MODE"}, {"name": "All Random", "value": "ALL_RANDOM"}, {"name": "Tournament Draft", "value": "TOURNAMENT_DRAFT"}]}}, "mapType": {"label": "Map Type", "description": "Select the map type", "isRequired": true, "defaultValue": "SUMMONERS_RIFT", "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Summoners Rift", "value": "SUMMONERS_RIFT"}, {"name": "Howling Abyss", "value": "HOWLING_ABYSS"}]}}, "serverRegion": {"label": "Server Region", "description": "Select the server region", "isRequired": true, "defaultValue": "NA", "component": "FormsySelectElement", "componentProps": {"options": [{"name": "BR", "value": "BR"}, {"name": "EUNE", "value": "EUNE"}, {"name": "EUW", "value": "EUW"}, {"name": "JP", "value": "JP"}, {"name": "LAN", "value": "LAN"}, {"name": "LAS", "value": "LAS"}, {"name": "NA", "value": "NA"}, {"name": "OCE", "value": "OCE"}, {"name": "PBE", "value": "PBE"}, {"name": "RU", "value": "RU"}, {"name": "TR", "value": "TR"}]}}, "spectatorType": {"label": "Spectator Options", "description": "Allow Spectators to join your matches", "isRequired": true, "defaultValue": "NONE", "component": "FormsySelectElement", "componentProps": {"options": [{"name": "No Spectators", "value": "NONE"}, {"name": "Lobby Only", "value": "LOBBYONLY"}, {"name": "All/Public", "value": "ALL"}]}}}, "expand": []}, {"id": 61, "videogameId": 1095, "name": "Fortnite Free-for-all", "description": null, "isDefault": true, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 62, "videogameId": 45, "name": "Gears of War 5v5", "description": "Standard 5v5 ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [261, 262, 263, 264, 265, 266, 267]}, "strikeOrder": [1, 1, 1, 1], "gameSetup": false, "characterSelectCount": 1, "pickSideBeforeMap": {"1": "Team A", "2": "Team B"}, "stageSelectAfterStrike": true, "stageSelectOverride": true, "oneCharacterForTeam": true, "matchSetupOnly": true, "matchSetup": true, "banTerm": "ban"}, "eventSettings": null, "expand": []}, {"id": 63, "videogameId": 1015, "name": "NBA2K18 Standard", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": 1, "cardLimit": null, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 64, "videogameId": 936, "name": "Duel Links", "description": "Ruleset for Duel Links", "isDefault": true, "gameMode": 1, "settings": [], "eventSettings": {"deckUploadMethod": {"label": "Deck Upload Method", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None", "value": 0}, {"name": "Upload Deck Image", "value": 1}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}}, "expand": []}, {"id": 65, "videogameId": 718, "name": "PUBG Free-for-all", "description": null, "isDefault": true, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 67, "videogameId": 718, "name": "PUBG Head-to-head", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"id": 68, "videogameId": 1095, "name": "Fortnite Head-to-head", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"id": 69, "videogameId": 2147, "name": "Ring Of Elysium Head-to-head", "description": "Current default head to head ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 70, "videogameId": 2147, "name": "Ring Of Elysium Free-for-all", "description": "Current Default FFA ruleset", "isDefault": true, "type": "standard", "gameMode": 2, "settings": {"type": "standard"}, "eventSettings": null, "expand": []}, {"id": 71, "videogameId": 2079, "name": "Icons: Combat Arena Standard Ruleset", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "stages": {"neutral": [280, 281, 282, 283, 284], "counterpick": []}, "gameSetup": 1, "additionalFlags": {"useMDSR": true, "disableBans": 3}}, "eventSettings": null, "expand": []}, {"id": 72, "videogameId": 43, "name": "Official Brood War Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [269, 290, 410, 411, 409]}, "strikeOrder": [1, 2, 1], "additionalFlags": {"firstStriker": 1}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 73, "videogameId": 1969, "name": "Slap City Standard Ruleset", "description": "This is the current default ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "strikeOrder": [1], "stages": {"neutral": [292, 293, 294], "counterpick": [295, 296, 297]}, "gameSetup": 1, "additionalFlags": {"stageSelectAfterStrike": true, "useMDSR": true, "ignoreBlind": true}}, "eventSettings": null, "expand": []}, {"id": 74, "videogameId": 2054, "name": "Mario Tennis Aces Simple Mode", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [301, 300, 298, 302, 303], "counterpick": [299, 304]}, "gameSetup": 1, "additionalFlags": {"firstStriker": 1, "banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 75, "videogameId": 44087, "name": "Overwatch Free-for-all", "description": "Free-for-all ruleset to be used for Overwatch Deathmatch", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 76, "videogameId": 2774, "name": "Call of Duty: Black Ops 4 Free-for-all", "description": "Call of Duty Free-for-all", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 77, "videogameId": 2774, "name": "Call of Duty: Black Ops 4 Head to Head", "description": "Call of Duty Head to Head", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 79, "videogameId": 193, "name": "ARMS Standard", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"strikeOrder": [1, 2, 1], "stages": {"neutral": [258, 243, 244, 259, 239], "counterpick": [260, 241]}, "additionalFlags": {"stageSelectAfterStrike": true, "banCount": 2, "characterSelectAfterStageSelect": true, "blindAfterStageSelect": true, "firstStriker": 1}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 80, "videogameId": 327, "name": "Splatoon 2 Standard Ruleset", "description": "This is the current default ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 81, "videogameId": 1386, "name": "SWT Ruleset", "description": "Official ruleset for Smash World Tour", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "stages": {"neutral": [311, 328, 397, 387, 378], "counterpick": [348, 353, 407, 484]}, "additionalFlags": {"useDSR": true, "banCount": 2}, "gameSetup": true, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 82, "videogameId": 1386, "name": "2GG Ruleset", "description": "This is the current default ruleset by 2GG", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "stages": {"neutral": [311, 328, 387, 378, 397], "counterpick": [348]}, "additionalFlags": {"useMDSR": false, "banCount": 2}, "gameSetup": true, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 83, "videogameId": 1386, "name": "Basic Ruleset - No Stages", "description": "Basic ruleset, only characters, no stages", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": 1, "cardLimit": null, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 84, "videogameId": 3161, "name": "MTG Arena", "description": "Default ruleset for MTG Arena", "isDefault": true, "gameMode": 1, "settings": [], "eventSettings": {"deckUploadMethod": {"label": "Deck Upload Method", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None", "value": 0}, {"name": "Upload Deck Image", "value": 1}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}}, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": null, "cardLimit": 30, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": true, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 85, "videogameId": 13, "name": "Custom", "description": null, "isDefault": false, "gameMode": 1, "settings": {"deckRestrictions": {"legendaryLimit": 1}, "gameSetup": true, "additionalFlags": {"classSelection": true}}, "eventSettings": {"classSelectionCount": {"label": "Class Count", "description": "Number of classes a user must select.", "isRequired": true, "defaultValue": 4, "component": "FormsyInputElement", "componentProps": {"type": "number"}}, "deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how users must display their decks.", "isRequired": true, "defaultValue": 2, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None - Class Selection Only", "value": 0}, {"name": "User Input", "value": 2}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 0, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}, "decksPerClass": {"label": "Decks Per Class", "isRequired": true, "defaultValue": 1, "component": "FormsyInputElement", "componentProps": {"type": "number", "inputProps": {"min": 1, "max": 10}}}, "requirePrimaryDeck": {"label": "Require Primary Deck", "description": "Require the player to specify a primary deck", "isRequired": true, "defaultValue": true, "component": "FormsyCheckbox", "componentProps": {"type": "number"}}}, "expand": []}, {"id": 86, "videogameId": 1386, "name": "GENESIS 2022 Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCount": 2, "useGenesisDSR": true}, "stages": {"neutral": [311, 328, 387, 378, 397], "counterpick": [484, 348]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 87, "videogameId": 1969, "name": "Slap City No Stage Striking", "description": "Stage striking left up to chat", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 89, "videogameId": 30, "name": "StarCraft II Free-for-all", "description": "Current Default FFA ruleset", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 90, "videogameId": 3465, "name": "Twitch Rivals Ruleset", "description": "A custom ruleset for the Twitch Rivals events.", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 91, "videogameId": 1386, "name": "Frostbite 2020 Ruleset", "description": "Smash Ultimate Ruleset for Frostbite 2020", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "stages": {"neutral": [311, 328, 387, 378, 397], "counterpick": [348, 353, 407]}, "additionalFlags": {"banCount": 2, "noStageBanOnWin": true, "useMDSR": true}, "gameSetup": true}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": null, "cardLimit": 30, "maxOverlap": null, "minOverlapWithPrimary": 25, "allowCharacterDupes": true, "classSelectionCount": 1, "decksPerClass": 3, "requirePrimaryDeck": true, "deckExternalLinkRegex": null, "id": 92, "videogameId": 13, "name": "Specialist", "description": "A single-class format, Specialist requires players to bring three decks of the same class. One deck is designated as primary, and the secondary and tertiary decks are then built around that, sharing at least 25 cards with the primary deck.", "isDefault": true, "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"classSelection": true}}, "eventSettings": {"deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how players must display their decks.", "isRequired": true, "defaultValue": 2, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None - Class Selection Only", "value": 0}, {"name": "User Input", "value": 2}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 0, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}}, "expand": []}, {"id": 93, "videogameId": 2165, "name": "Pax Arena Ruleset", "description": "Ruleset for PAX Arena", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 94, "videogameId": 3465, "name": "Apex Legends Free-for-all - Squads", "description": "A free-for-all format for Apex Legends", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 95, "videogameId": 3465, "name": "Apex Legends Head-to-head", "description": "A head-to-head format for Apex Legends", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 96, "videogameId": 3200, "name": "Mortal Kombat 11 Ruleset", "description": "The default Mortal Kombat 11 ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "blindBeforeAll": true}, "eventSettings": null, "expand": []}, {"id": 97, "videogameId": 865, "name": "Halo 5 Race Runner Ruleset", "description": "Race Runner Ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"allowedReportingModes": "", "autoReportingConfig": {"streamWatchType": "mixer", "sessionStartBuffer": 600, "sessionEndBuffer": 60, "reportingBuffer": 300, "sessionReuseBuffer": 300, "gameAPI": "Halo5API"}}, "eventSettings": null, "expand": []}, {"id": 98, "videogameId": 1386, "name": "Evo 2019 Ruleset", "description": "Smash Ultimate Ruleset for Evo 2019", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 328, 378, 387, 397], "counterpick": [348, 353, 406, 407]}, "additionalFlags": {"banCount": 2, "useMDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 99, "videogameId": 10, "name": "League of Legends Race Runner Ruleset", "description": "Race Runner Ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"allowedReportingModes": "", "autoReportingConfig": {"streamWatchType": "mixer", "sessionStartBuffer": 600, "sessionEndBuffer": 60, "reportingBuffer": 300, "sessionReuseBuffer": 300, "gameAPI": "riot-games-api"}}, "eventSettings": null, "expand": []}, {"id": 100, "videogameId": 791, "name": "Paladins Race Runner Ruleset", "description": "Race Runner Ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"allowedReportingModes": "", "autoReportingConfig": {"streamWatchType": "mixer", "sessionStartBuffer": 600, "sessionEndBuffer": 60, "reportingBuffer": 300, "sessionReuseBuffer": 300, "gameAPI": "PaladinsAPI"}}, "eventSettings": null, "expand": []}, {"id": 104, "videogameId": 2555, "name": "Halo 3: MCC Free-for-all - Solos", "description": "FFA Ruleset for Halo 3: Master Chief Collection", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 105, "videogameId": 2555, "name": "Halo 3: MCC Head-to-head", "description": "A head-to-head format for Halo 3: Master Chief Collection", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 106, "videogameId": 3428, "name": "DOTA 2 Auto Chess Free-for-all", "description": "FFA Ruleset for DOTA 2 Auto Chess", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 107, "videogameId": 3428, "name": "DOTA 2 Auto Chess Head-to-head", "description": "A head-to-head format for DOTA 2 Auto Chess", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 108, "videogameId": 33594, "name": "Teamfight Tactics Free-for-all", "description": "FFA Ruleset for Teamfight Tactics", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 109, "videogameId": 33594, "name": "Teamfight Tactics Head-to-head", "description": "A head-to-head format for Teamfight Tactics", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 110, "videogameId": 33595, "name": "Dota Underlords Free-for-all", "description": "FFA Ruleset for Dota Underlords", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 111, "videogameId": 33595, "name": "Dota Underlords Head-to-head", "description": "A head-to-head format for Dota Underlords", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 112, "videogameId": 2054, "name": "Mario Tennis Aces Standard Mode", "description": "2019 Standard Mode Ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [298, 299, 300, 301, 303], "counterpick": [302, 304]}, "gameSetup": true, "additionalFlags": {"firstStriker": 1, "banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 113, "videogameId": 33577, "name": "Crash Team Racing Nitro-Fueled Free-for-all", "description": "FFA Ruleset for Crash Team Racing Nitro-Fueled", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 114, "videogameId": 3465, "name": "Mixer Apex Legends Race Runner Ruleset", "description": "Race Runner Ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"allowedReportingModes": "", "autoReportingConfig": {"streamWatchType": "mixer", "sessionStartBuffer": 600, "sessionEndBuffer": 60, "reportingBuffer": 300, "sessionReuseBuffer": 300, "gameAPI": "WatchForAPI"}}, "eventSettings": null, "expand": []}, {"id": 115, "videogameId": 1386, "name": "Shine 2019 Ruleset", "description": "Smash Ultimate Ruleset for Shine 2019", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 328, 378, 387, 397], "counterpick": [348, 407]}, "additionalFlags": {"banCount": 2, "useMDSR": true}}, "eventSettings": null, "expand": []}, {"id": 116, "videogameId": 33754, "name": "Chess Rush Free-for-all", "description": "FFA Ruleset for Chess Rush", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 117, "videogameId": 33754, "name": "Chess Rush Head-to-head", "description": "A head-to-head format for Chess Rush", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 118, "videogameId": 1095, "name": "Mixer WatchForAPI Race Runner", "description": "Race Runner Ruleset", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"allowedReportingModes": "", "autoReportingConfig": {"streamWatchType": "mixer", "sessionStartBuffer": 1200, "sessionEndBuffer": 300, "reportingBuffer": 300, "sessionReuseBuffer": 300, "gameAPI": "WatchForAPI"}}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": 1, "cardLimit": 30, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 119, "videogameId": 33638, "name": "TEPPEN", "description": "TEPPEN Base Ruleset with Deck Support", "isDefault": true, "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"classSelection": true}}, "eventSettings": {"deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how players must display their decks.", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "None", "value": 0}, {"name": "Upload Deck Image", "value": 1}]}}, "deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}}, "expand": []}, {"id": 120, "videogameId": 3465, "name": "Apex Legends H2H with WatchFor Reporting", "description": "Proprietary Mixer Ruleset integrating the WatchFor API", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "reportingApi": "WatchForAPI"}, "eventSettings": null, "expand": []}, {"id": 121, "videogameId": 1095, "name": "Fortnite H2H with WatchFor Reporting", "description": "Proprietary Mixer Ruleset integrating the WatchFor API", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "reportingApi": "WatchForAPI"}, "eventSettings": null, "expand": []}, {"id": 122, "videogameId": 31, "name": "Standard - No Stages", "description": "Basic Ruleset for Overwatch with no Stage Striking", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "additionalFlags": {"ignoreCharacters": true, "pickSideAfterMap": {"1": "Blue (Defend)", "2": "Red (Attack)"}}}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": 1, "cardLimit": null, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 124, "videogameId": 342, "name": "Pokemon TCG Online", "description": "Pokemon TCG Online ruleset", "isDefault": true, "gameMode": 1, "settings": [], "eventSettings": {"deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}, "deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how players must display their decks.", "isRequired": true, "defaultValue": 3, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Players enter a link to their deck on an external site", "value": 3}, {"name": "Disable decks", "value": 0}]}}}, "expand": []}, {"id": 125, "videogameId": 1386, "name": "Syndicate 2019 Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [387, 311, 378, 328, 353], "counterpick": [397, 348]}, "additionalFlags": {"useMDSR": false, "banCount": 2}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 126, "videogameId": 1386, "name": "GOML Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 378, 387, 397, 328], "counterpick": [348, 407]}, "additionalFlags": {"banCount": 2}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": 1, "cardLimit": null, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 127, "videogameId": 34062, "name": "Legends of Runeterra", "description": "Legends of Runeterra ruleset", "isDefault": true, "gameMode": 1, "settings": [], "eventSettings": {"deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}, "deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how players must display their decks.", "isRequired": true, "defaultValue": 3, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Players enter a link to their deck on an external site", "value": 3}, {"name": "Disable decks", "value": 0}]}}}, "expand": []}, {"id": 128, "videogameId": 287, "name": "DBFZ No Character Select", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "ignoreCharacters": true, "characterSelectCount": 3, "uniqueCharacters": true}, "eventSettings": null, "expand": []}, {"id": 129, "videogameId": 1386, "name": "Collision Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 378, 387, 484, 328], "counterpick": [397]}, "additionalFlags": {"banCount": 2}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 130, "videogameId": 2, "name": "PMBR Recommended", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [92, 116, 121, 105, 130], "counterpick": [100, 102, 125, 98, 111]}, "additionalFlags": {"banCount": 2, "useMDSR": true, "chooseCharacterBeforeStageSelect": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 131, "videogameId": 33602, "name": "PMBR Recommended", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [418, 442, 447, 431, 456], "counterpick": [426, 428, 451, 424, 437]}, "additionalFlags": {"banCount": 2, "useMDSR": true, "chooseCharacterBeforeStageSelect": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 132, "videogameId": 33823, "name": "Call of Duty: Mobile Head to Head", "description": "Call of Duty Head to Head", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 133, "videogameId": 33823, "name": "Call of Duty: Mobile Free-for-all", "description": "Call of Duty Free-for-all", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 134, "videogameId": 33528, "name": "GRID Free-for-all", "description": "GRID Free-for-all", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 135, "videogameId": 34176, "name": "Call of Duty: Warzone Head to Head", "description": "Call of Duty Head to Head", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1}, "eventSettings": null, "expand": []}, {"id": 136, "videogameId": 34176, "name": "Call of Duty: Warzone Free-for-all", "description": "Call of Duty Free-for-all", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 137, "videogameId": 1095, "name": "Fortnite Dreamhack Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": {"ffaPointConfig": [{"type": "map", "field": "placement", "config": {"map": {"1": 60, "2": 53, "3": 49, "4": 47, "5": 46, "6": 45, "7": 44, "8": 43, "9": 42, "10": 41, "11": 40, "12": 39, "13": 38, "14": 37, "15": 36, "16": 35, "17": 34, "18": 33, "19": 32, "20": 31, "21": 30, "22": 29, "23": 28, "24": 27, "25": 26, "26": 25, "27": 24, "28": 23, "29": 22, "30": 21, "31": 20, "32": 19, "33": 18, "34": 17, "35": 16, "36": 15, "37": 14, "38": 13, "39": 12, "40": 11, "41": 10, "42": 9, "43": 8, "44": 7, "45": 6, "46": 5, "47": 4, "48": 3, "49": 2, "50": 1}}}, {"type": "multiply", "field": "kills", "config": {"multiplier": 5}}]}, "expand": []}, {"id": 138, "videogameId": 1, "name": "Rollback Rumble Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [5, 11, 15, 19, 25], "counterpick": [20]}, "additionalFlags": {"disableBans": 3, "useMDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 139, "videogameId": 1386, "name": "The Box Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 328, 397, 378, 387], "counterpick": [348, 407]}, "additionalFlags": {"banCount": 2, "useDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 140, "videogameId": 1969, "name": "SCO Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [293, 294, 292, 482, 483], "counterpick": [295]}, "additionalFlags": {"disableBans": 3, "useDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 141, "videogameId": 1386, "name": "Naifu Wars Ruleset", "description": "Smash Ultimate ruleset used by Naifu Wars", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 378, 387, 397, 328], "counterpick": [406, 407, 348, 353]}, "additionalFlags": {"banCount": 3, "useDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 142, "videogameId": 1386, "name": "Small Battlefield Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 328, 387, 378, 484], "counterpick": [348, 353, 407, 397]}, "additionalFlags": {"banCount": 3, "useDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 143, "videogameId": 1386, "name": "The Box (SBF Edition)", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [311, 328, 378, 387, 397], "counterpick": [348, 407, 484]}, "additionalFlags": {"banCount": 2, "useDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 144, "videogameId": 35033, "name": "Tony Hawk's Pro Skater 1+2 Free-for-all", "description": "Tony Hawk's Pro Skater 1+2 Free-for-all", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 145, "videogameId": 34863, "name": "Rushdown Revolt Standard", "description": "Rushdown Revolt Standard Head to Head Ruleset", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [489, 490, 491, 493, 494], "counterpick": [492, 495, 508]}, "additionalFlags": {"useMDSR": true, "banCount": 2}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 146, "videogameId": 2054, "name": "Simple Doubles", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [298, 301, 303, 299], "counterpick": []}, "additionalFlags": {"disableBans": true, "stageSelectAfterStrike": true, "firstStriker": 1}, "strikeOrder": [2]}, "eventSettings": null, "expand": []}, {"id": 148, "videogameId": 35367, "name": "Free-for-all", "description": "", "isDefault": true, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 151, "videogameId": 1386, "name": "Frame Perfect Series", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"stages": {"neutral": [311, 328, 387, 378, 397, 407, 353], "counterpick": [484, 406, 318, 401, 399, 348, 497]}, "additionalFlags": {"banCount": 3, "useMDSR": true}, "type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 153, "videogameId": 88, "name": "PC Beta", "description": "Ruleset for PC Beta", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "strikeOrder": [1, 1, 1, 1], "stages": {"neutral": [208, 274, 498, 233, 496], "counterpick": [276, 246, 277], "strikeOrder": [1, 1, 1, 1]}, "additionalFlags": [], "gameSetup": true}, "eventSettings": null, "expand": []}, {"id": 154, "videogameId": 35957, "name": "Eternal Return: Black Survival Free-for-all", "description": "", "isDefault": true, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 155, "videogameId": 1386, "name": "Syndicate Doubles Ruleset", "description": "", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [397, 311, 377, 328, 353], "counterpick": [416, 348]}, "additionalFlags": {"useMDSR": false, "banCount": 2}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 159, "videogameId": 16729, "name": "Pinball FX3 Free-for-all", "description": "", "isDefault": true, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 160, "videogameId": 88, "name": "Modified Recommended Ruleset (PC, 5 starters)", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [208, 274, 498, 233, 496], "counterpick": [276, 277, 246, 247]}, "additionalFlags": {"useMDSR": true, "banCount": 0, "banCountByMaxGames": {"3": 3, "5": 2}}}, "eventSettings": null, "expand": []}, {"id": 161, "videogameId": 88, "name": "Community Recommended Ruleset (PC)", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [3, 2], "stages": {"neutral": [208, 274, 498, 233, 496, 247], "counterpick": [276, 277, 246]}, "additionalFlags": {"useMDSR": true, "banCount": 0, "banCountByMaxGames": {"3": 3, "5": 2}}}, "eventSettings": null, "expand": []}, {"id": 162, "videogameId": 88, "name": "Community Recommended Ruleset (Consoles)", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [208, 274, 233, 496, 247], "counterpick": [276, 277, 246]}, "additionalFlags": {"useMDSR": true, "banCount": 0, "banCountByMaxGames": {"3": 2, "5": 1}}}, "eventSettings": null, "expand": []}, {"id": 163, "videogameId": 1386, "name": "Wario's Smash Down", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [311, 328, 484, 387, 397], "counterpick": [378, 497, 407, 348]}, "additionalFlags": {"useDSR": true, "banCount": 3}}, "eventSettings": null, "expand": []}, {"id": 164, "videogameId": 1386, "name": "MDVA Classic", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [328, 311, 387, 378, 397], "counterpick": [348, 353, 407]}, "additionalFlags": {"useDSR": false, "banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 165, "videogameId": 34915, "name": "Demo Friendly Stage List (Europe)", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [504, 506, 502, 499, 507], "counterpick": [503, 500]}, "additionalFlags": {"banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 166, "videogameId": 34915, "name": "Frame Perfect Series (USA)", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 2, 1], "stages": {"neutral": [504, 500, 502, 499, 501], "counterpick": [506, 505]}, "additionalFlags": {"banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 167, "videogameId": 34915, "name": "Japanese Stage List", "description": "", "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameSetup": true, "gameMode": 1, "strikeOrder": [1, 1, 1], "stages": {"neutral": [504, 502, 499, 501], "counterpick": [506, 505]}, "additionalFlags": {"banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 168, "videogameId": 34161, "name": "Free Fire Free-for-all", "description": "", "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 169, "videogameId": 1, "name": "LEVO Ruleset", "description": "DSR except first stage", "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"type": "standard", "gameMode": 1, "gameSetup": true, "stages": {"neutral": [5, 19, 15, 25, 11], "counterpick": [20]}, "additionalFlags": {"useLEVOmDSR": true}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 170, "videogameId": 37843, "name": "Financial Modeling Free-for-all", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 171, "videogameId": 1, "name": "Melee Doubles", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "stages": {"neutral": [20, 19, 5, 25, 15]}, "strikeOrder": [1, 2, 1], "additionalFlags": {"useMDSR": true, "disableBans": 3}}, "eventSettings": null, "expand": []}, {"id": 172, "videogameId": 1386, "name": "Community CUP", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "stages": {"neutral": [311, 328, 397, 378, 387], "counterpick": [497, 484, 407, 348]}, "strikeOrder": [1, 2, 1], "additionalFlags": {"useDSR": true, "banCount": 2}}, "eventSettings": null, "expand": []}, {"id": 173, "videogameId": 1386, "name": "Wanted Online - Northern Cave", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "stages": {"neutral": [311, 484, 328, 407, 378, 387, 353, 397, 497]}, "strikeOrder": [3, 4, 1], "additionalFlags": {"banCount": 3}}, "eventSettings": null, "expand": []}, {"id": 174, "videogameId": 1386, "name": "Wanted Online - Kalos League", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "stages": {"neutral": [311, 484, 328, 407, 378, 387, 353, 397, 348]}, "strikeOrder": [3, 4, 1], "additionalFlags": {"banCount": 3}}, "eventSettings": null, "expand": []}, {"id": 175, "videogameId": 22254, "name": "Official Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"id": 176, "videogameId": 38949, "name": "Competitive Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": false, "additionalFlags": {"ignoreCharacters": true}}, "eventSettings": null, "expand": []}, {"id": 177, "videogameId": 1386, "name": "Charles Stage List", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"useMDSR": true, "banCount": 1}, "stages": {"neutral": [311, 484, 387, 397, 328], "counterpick": [331]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 178, "videogameId": 1800, "name": "Free-for-all", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": {"type": "standard", "gameMode": 2}, "eventSettings": null, "expand": []}, {"id": 179, "videogameId": 33602, "name": "Default", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": null, "eventSettings": null, "expand": []}, {"id": 180, "videogameId": 39281, "name": "Standard Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"chooseCharacterBeforeStageSelect": true, "firstStriker": 1, "useMDSR": true, "banCountByMaxGames": {"3": 2, "5": 1}}, "stages": {"neutral": [509, 518, 511, 512, 550], "counterpick": [551, 552, 519]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 181, "videogameId": 1386, "name": "Experimental Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCountByMaxGames": {"3": 3, "5": 2}, "useDSR": true}, "stages": {"neutral": [311, 484, 387, 328, 397], "counterpick": [378, 407, 513, 348]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 182, "videogameId": 40325, "name": "Competitive Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"selectFromAllStages": true, "chooseCharacterBeforeStageSelect": true}, "stages": {"neutral": [522, 523, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567]}, "strikeOrder": [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 183, "videogameId": 34245, "name": "Standard Ruleset", "description": null, "isDefault": true, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": [], "stages": {"neutral": [514, 515, 516, 517]}, "strikeOrder": [1, 1, 1]}, "eventSettings": null, "expand": []}, {"id": 184, "videogameId": 39281, "name": "CG 2v2 Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCountByMaxGames": {"3": 1, "5": 0}, "useMDSR": true}, "stages": {"neutral": [509, 510, 511, 512, 518], "counterpick": []}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 185, "videogameId": 1969, "name": "2022 Standard Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCount": 2, "useDSR": true}, "stages": {"neutral": [293, 294, 292, 483, 482], "counterpick": [520, 295, 521]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"type": "deck", "cardDupeLimit": null, "deckLimit": 1, "cardLimit": null, "maxOverlap": null, "minOverlapWithPrimary": null, "allowCharacterDupes": false, "classSelectionCount": null, "decksPerClass": null, "requirePrimaryDeck": null, "deckExternalLinkRegex": null, "id": 186, "videogameId": 40908, "name": "Yu-Gi-Oh! Master Duel", "description": "Yu-Gi-Oh! Master Duel ruleset", "isDefault": true, "gameMode": 1, "settings": [], "eventSettings": {"deckDeadlineBehavior": {"label": "Deck Deadline Behavior", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Remove Entrant From Bracket", "value": 0}, {"name": "Do Not Remove Entrant", "value": 1}]}}, "deckUploadMethod": {"label": "Deck Upload Method", "description": "Defines how players must display their decks.", "isRequired": true, "defaultValue": 1, "component": "FormsySelectElement", "componentProps": {"options": [{"name": "Disable decks", "value": 0}, {"name": "Players upload images of their deck", "value": 1}]}}}, "expand": []}, {"id": 187, "videogameId": 5682, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 188, "videogameId": 4743, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 189, "videogameId": 22254, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 190, "videogameId": 33335, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 191, "videogameId": 39281, "name": "CG 1v1 Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"useDSR": true, "banCount": 1}, "stages": {"neutral": [509, 511, 518], "counterpick": [512, 510, 519]}, "strikeOrder": [1, 1]}, "eventSettings": null, "expand": []}, {"id": 192, "videogameId": 1386, "name": "Panda Cup Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"useDSR": true, "banCount": 2}, "stages": {"neutral": [378, 387, 397, 311, 328], "counterpick": [348, 484, 353]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 193, "videogameId": 1386, "name": "EU Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCount": 3, "chooseCharacterBeforeStageSelect": true}, "stages": {"neutral": [311, 484, 328, 407, 378, 387, 397, 348, 513]}, "strikeOrder": [3, 4, 1]}, "eventSettings": null, "expand": []}, {"id": 194, "videogameId": 40325, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 195, "videogameId": 38859, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 196, "videogameId": 40849, "name": "MegaVersus Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"0": "uniqueTeamCharacters", "1": "selectFromAllStages", "banCount": 2}, "stages": {"neutral": [544, 545, 546, 555, 548, 549]}, "strikeOrder": [1, 1, 1, 1, 1]}, "eventSettings": null, "expand": []}, {"id": 197, "videogameId": 40849, "name": "Warner Bros MVS Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"0": "uniqueTeamCharacters", "1": "chooseCharacterBeforeStageSelect", "useDSR": true, "banCount": 2}, "stages": {"neutral": [544, 545, 546, 547, 548, 549, 553, 554]}, "strikeOrder": [1, 1, 1, 1, 1, 1, 1]}, "eventSettings": null, "expand": []}, {"id": 198, "videogameId": 45115, "name": "FFA", "description": null, "isDefault": false, "type": "standard", "gameMode": 2, "settings": null, "eventSettings": null, "expand": []}, {"id": 199, "videogameId": 39281, "name": "Community Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCountByMaxGames": {"3": 2, "5": 1}, "useMDSR": true}, "stages": {"neutral": [550, 512, 518, 509, 511], "counterpick": [519, 551, 552]}, "strikeOrder": [1, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 200, "videogameId": 40849, "name": "Warner Bros MVS 2v2 Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"0": "uniqueTeamCharacters", "1": "chooseCharacterBeforeStageSelect", "useDSR": true, "banCount": 2}, "stages": {"neutral": [544, 545, 546, 547, 548, 549, 553, 554, 555]}, "strikeOrder": [1, 1, 1, 1, 1, 1, 1, 1]}, "eventSettings": null, "expand": []}, {"id": 203, "videogameId": 15, "name": "Brawlhalla Singles", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"selectFromAllStages": true, "disableBans": true}, "stages": {"neutral": [268, 279, 415, 460, 541, 543, 556]}, "strikeOrder": [1, 2, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 204, "videogameId": 15, "name": "Brawlhalla Doubles", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"selectFromAllStages": true, "disableBans": true}, "stages": {"neutral": [268, 415, 460, 541, 543, 556, 557]}, "strikeOrder": [1, 2, 2, 1]}, "eventSettings": null, "expand": []}, {"id": 206, "videogameId": 46120, "name": "Standard Ruleset", "description": null, "isDefault": false, "type": "standard", "gameMode": 1, "settings": {"gameSetup": true, "additionalFlags": {"banCount": 3}, "stages": {"neutral": [568, 569, 570, 571, 572, 573, 574]}, "strikeOrder": [1, 1, 1, 2, 1]}, "eventSettings": null, "expand": []}]
+[
+    {
+        "id": 2,
+        "videogameId": 1,
+        "name": "Full Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": null,
+            "gameMode": null,
+            "strikeOrder": null,
+            "stages": {
+                "neutral": [
+                    5,
+                    11,
+                    19,
+                    20,
+                    25
+                ],
+                "counterpick": [
+                    15
+                ]
+            },
+            "gameSetup": 1,
+            "additionalFlags": {
+                "disableBans": 3,
+                "useMDSR": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 3,
+        "videogameId": 3,
+        "name": null,
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    30,
+                    34,
+                    31,
+                    37,
+                    36
+                ],
+                "counterpick": [
+                    38,
+                    39
+                ]
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 4,
+        "videogameId": 29,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": [
+                1,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    158,
+                    159,
+                    160
+                ],
+                "counterpick": [
+                    161,
+                    162,
+                    163,
+                    164
+                ]
+            },
+            "gameSetup": true,
+            "banCount": null,
+            "additionalFlags": {
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 5,
+        "videogameId": 7,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "doubleBlindOnly": true,
+            "additionalFlags": [],
+            "matchSetupOnly": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 6,
+        "videogameId": 25,
+        "name": "DO NOT USE",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "deckSetup": true,
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 7,
+        "videogameId": 26,
+        "name": "Official Battlerite Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": {
+                "1": [
+                    2,
+                    2,
+                    2,
+                    1,
+                    1,
+                    1
+                ],
+                "3": [
+                    2,
+                    2,
+                    1,
+                    1,
+                    1
+                ],
+                "5": [
+                    2,
+                    1,
+                    1
+                ]
+            },
+            "stages": {
+                "neutral": [
+                    165,
+                    166,
+                    167,
+                    168,
+                    169,
+                    170,
+                    171,
+                    172,
+                    212,
+                    213
+                ]
+            },
+            "additionalFlags": {
+                "maintainStrikes": true,
+                "stageSelectAfterStrike": true,
+                "disableBans": true,
+                "firstStriker": 1,
+                "individualCharBlind": true,
+                "uniqueTeamCharacters": true,
+                "blindBeforeAll": true,
+                "characterSelectAfterStageSelect": true
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 8,
+        "videogameId": 30,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": {
+                "1": [
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
+                ],
+                "3": [
+                    1,
+                    1,
+                    1,
+                    1
+                ],
+                "5": [
+                    1,
+                    1
+                ]
+            },
+            "stages": {
+                "neutral": [
+                    193,
+                    214,
+                    215,
+                    216,
+                    217,
+                    195,
+                    218
+                ]
+            },
+            "additionalFlags": {
+                "maintainStrikes": true,
+                "stageSelectAfterStrike": true,
+                "disableBans": true,
+                "ignoreCharacters": "blind_only",
+                "stageSelectOverride": 2,
+                "firstStriker": 2
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 9,
+        "videogameId": 44087,
+        "name": "Standard",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    173,
+                    174,
+                    175,
+                    176,
+                    177,
+                    178,
+                    179,
+                    180,
+                    181,
+                    182,
+                    183,
+                    184,
+                    185,
+                    205
+                ]
+            },
+            "additionalFlags": {
+                "selectFromAllStages": true,
+                "maintainStrikes": true,
+                "disableBans": true,
+                "ignoreCharacters": true,
+                "pickSideAfterMap": {
+                    "1": "Blue (Defend)",
+                    "2": "Red (Attack)"
+                }
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 10,
+        "videogameId": 31,
+        "name": "Custom Overwatch",
+        "description": "Map striking goes 1-1-1... etc.",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    173,
+                    174,
+                    175,
+                    176,
+                    177,
+                    178,
+                    179,
+                    180,
+                    181,
+                    182,
+                    183,
+                    184,
+                    185,
+                    205
+                ]
+            },
+            "additionalFlags": {
+                "disableBans": true,
+                "ignoreCharacters": true,
+                "pickSideAfterMap": {
+                    "1": "Blue (Defend)",
+                    "2": "Red (Attack)"
+                },
+                "stageSelectAfterStrike": true
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 11,
+        "videogameId": 41,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "doubleBlindOnly": true,
+            "additionalFlags": [],
+            "matchSetupOnly": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 13,
+        "videogameId": 40,
+        "name": "Official For Honor Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "blindBeforeAll": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 16,
+        "videogameId": 3,
+        "name": "Smash 4 Recommended Global Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    204,
+                    34,
+                    31,
+                    37,
+                    36
+                ]
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 17,
+        "videogameId": 25,
+        "name": "Blind Player Order",
+        "description": "This ruleset has no deck selection but has a setup task for blindly choosing the order of players on each team",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "additionalFlags": {
+                "doubleBlindOrder": true
+            },
+            "matchSetupOnly": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": 1,
+        "deckLimit": 2,
+        "cardLimit": 8,
+        "maxOverlap": 4,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": null,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 31,
+        "videogameId": 25,
+        "name": "Clash Royale",
+        "description": "Official Clash Ruleset",
+        "isDefault": null,
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": 2,
+        "deckLimit": null,
+        "cardLimit": 30,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": null,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 32,
+        "videogameId": 13,
+        "name": "Hearthstone",
+        "description": "Hearthstone Ruleset",
+        "isDefault": false,
+        "gameMode": 1,
+        "settings": {
+            "deckRestrictions": {
+                "legendaryLimit": 1
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 33,
+        "videogameId": 40,
+        "name": "For Honor No Character Selection",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 34,
+        "videogameId": 88,
+        "name": "Brawlout Standard",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    208,
+                    274,
+                    247,
+                    233,
+                    496
+                ],
+                "counterpick": [
+                    276,
+                    246,
+                    277
+                ],
+                "strikeOrder": [
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "additionalFlags": [],
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": 2,
+        "deckLimit": null,
+        "cardLimit": 30,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 35,
+        "videogameId": 13,
+        "name": "Conquest",
+        "description": "Ruleset for Hearthstone conquest game mode.",
+        "isDefault": false,
+        "gameMode": 1,
+        "settings": {
+            "deckRestrictions": {
+                "legendaryLimit": 1
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "classSelection": true,
+                "deckDisableMode": "winners"
+            }
+        },
+        "eventSettings": {
+            "classSelectionCount": {
+                "label": "Class Count",
+                "description": "Number of classes a user must select.",
+                "isRequired": true,
+                "defaultValue": 4,
+                "component": "FormsyInputElement",
+                "componentProps": {
+                    "type": "number"
+                }
+            },
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how users must display their decks.",
+                "isRequired": true,
+                "defaultValue": 2,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None - Class Selection Only",
+                            "value": 0
+                        },
+                        {
+                            "name": "User Input",
+                            "value": 2
+                        }
+                    ]
+                }
+            },
+            "includeClassBanStep": {
+                "label": "Include Class Ban Step",
+                "description": "Determines if a ban step is added to the start of the game.",
+                "isRequired": true,
+                "defaultValue": true,
+                "component": "FormsyRadioElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Yes",
+                            "description": "Add a class banning step to the start of a match. Number of classes required must exceed the number of wins required.",
+                            "value": true
+                        },
+                        {
+                            "name": "No",
+                            "description": "Classes will not be banned.",
+                            "value": false
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 0,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": 2,
+        "deckLimit": null,
+        "cardLimit": 30,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 36,
+        "videogameId": 13,
+        "name": "Last Hero Standing",
+        "description": "Ruleset for Hearthstone last hero standing game mode.",
+        "isDefault": false,
+        "gameMode": 1,
+        "settings": {
+            "deckRestrictions": {
+                "legendaryLimit": 1
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "classSelection": true,
+                "deckDisableMode": "losers"
+            }
+        },
+        "eventSettings": {
+            "classSelectionCount": {
+                "label": "Class Count",
+                "description": "Number of classes a user must select.",
+                "isRequired": true,
+                "defaultValue": 4,
+                "component": "FormsyInputElement",
+                "componentProps": {
+                    "type": "number"
+                }
+            },
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how users must display their decks.",
+                "isRequired": true,
+                "defaultValue": 2,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None - Class Selection Only",
+                            "value": 0
+                        },
+                        {
+                            "name": "User Input",
+                            "value": 2
+                        }
+                    ]
+                }
+            },
+            "includeClassBanStep": {
+                "label": "Include Class Ban Step",
+                "description": "Determines if a ban step is added to the start of the game.",
+                "isRequired": true,
+                "defaultValue": true,
+                "component": "FormsyRadioElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Yes",
+                            "description": "Add a class banning step to the start of a match. Number of classes required must exceed the number of wins required.",
+                            "value": true
+                        },
+                        {
+                            "name": "No",
+                            "description": "Classes will not be banned.",
+                            "value": false
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 0,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 37,
+        "videogameId": 40,
+        "name": "Verification Test",
+        "description": "UserMedia Verification Testing Ruleset",
+        "isDefault": null,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameVerification": {
+                "mediaType": "webpage",
+                "contentType": "verification"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 38,
+        "videogameId": 25,
+        "name": "Clash Default",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 41,
+        "videogameId": 120,
+        "name": "Pokemon Showdown 1v1 Ruleset",
+        "description": "Requires URL replay uploads",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameVerification": {
+                "mediaType": "webpage",
+                "contentType": "verification"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 42,
+        "videogameId": 1,
+        "name": "Basic Tasks",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 43,
+        "videogameId": 35,
+        "name": "Standard Injustice 2 Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 44,
+        "videogameId": 3,
+        "name": "Smash 4 Standard Ruleset",
+        "description": "Current default ruleset for Smash 4",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    204,
+                    34,
+                    31,
+                    37,
+                    36
+                ]
+            },
+            "gameSetup": 1,
+            "additionalFlags": {
+                "useMDSR": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 45,
+        "videogameId": 294,
+        "name": "Form Ball",
+        "description": "Default ruleset for Form Ball",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 46,
+        "videogameId": 294,
+        "name": "Deathmatch (small)",
+        "description": "Ruleset for 2-4 Players",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    221,
+                    222,
+                    223
+                ]
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "ignoreCharacters": true
+            },
+            "strikeOrder": [
+                1,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 47,
+        "videogameId": 294,
+        "name": "Deathmatch (medium)",
+        "description": "Ruleset for 4-6 Players",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    224,
+                    225,
+                    221,
+                    222,
+                    223
+                ]
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "ignoreCharacters": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 48,
+        "videogameId": 294,
+        "name": "Deathmatch (large)",
+        "description": "Ruleset for 6-8 Players",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    226,
+                    227,
+                    228,
+                    224,
+                    225
+                ]
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "ignoreCharacters": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 49,
+        "videogameId": 562,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "doubleBlindOnly": true,
+            "additionalFlags": [],
+            "matchSetupOnly": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 51,
+        "videogameId": 287,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "doubleBlindOnly": true,
+            "additionalFlags": [],
+            "characterSelectCount": 3,
+            "gameSetup": true,
+            "uniqueCharacters": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 52,
+        "videogameId": 288,
+        "name": null,
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "doubleBlindOnly": true,
+            "additionalFlags": [],
+            "characterSelectCount": 2,
+            "gameSetup": true,
+            "uniqueCharacters": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 53,
+        "videogameId": 193,
+        "name": "ARMS Standard",
+        "description": "Old ARMS standard ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    258,
+                    243,
+                    239,
+                    259,
+                    244
+                ],
+                "counterpick": [
+                    260,
+                    241
+                ]
+            },
+            "additionalFlags": {
+                "stageSelectAfterStrike": true,
+                "banCount": 2
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 54,
+        "videogameId": 705,
+        "name": "Tooth and Tail Standard",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 55,
+        "videogameId": 718,
+        "name": "PUBG FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 56,
+        "videogameId": 752,
+        "name": "Quake Champions Standard",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 57,
+        "videogameId": 752,
+        "name": "Quake Champions Sacrifice (4v4)",
+        "description": "This is the Sacrifice (4v4) ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "characterSelectCount": 1,
+            "gameSetup": true,
+            "additionalFlags": {
+                "individualCharBlind": false
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 58,
+        "videogameId": 865,
+        "name": "Halo 5 Default",
+        "description": "Halo 5 standard 4v4 ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 59,
+        "videogameId": 865,
+        "name": "Halo 5 FFA",
+        "description": "Halo 5 FFA ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 60,
+        "videogameId": 10,
+        "name": "League Of Legends Standard Ruleset",
+        "description": "This is the Standard League of Legends ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": {
+            "pickType": {
+                "label": "Pick Type",
+                "description": "Determine the pick type of the game",
+                "isRequired": true,
+                "defaultValue": "BLIND_PICK",
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Blind Pick",
+                            "value": "BLIND_PICK"
+                        },
+                        {
+                            "name": "Draft Mode",
+                            "value": "DRAFT_MODE"
+                        },
+                        {
+                            "name": "All Random",
+                            "value": "ALL_RANDOM"
+                        },
+                        {
+                            "name": "Tournament Draft",
+                            "value": "TOURNAMENT_DRAFT"
+                        }
+                    ]
+                }
+            },
+            "mapType": {
+                "label": "Map Type",
+                "description": "Select the map type",
+                "isRequired": true,
+                "defaultValue": "SUMMONERS_RIFT",
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Summoners Rift",
+                            "value": "SUMMONERS_RIFT"
+                        },
+                        {
+                            "name": "Howling Abyss",
+                            "value": "HOWLING_ABYSS"
+                        }
+                    ]
+                }
+            },
+            "serverRegion": {
+                "label": "Server Region",
+                "description": "Select the server region",
+                "isRequired": true,
+                "defaultValue": "NA",
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "BR",
+                            "value": "BR"
+                        },
+                        {
+                            "name": "EUNE",
+                            "value": "EUNE"
+                        },
+                        {
+                            "name": "EUW",
+                            "value": "EUW"
+                        },
+                        {
+                            "name": "JP",
+                            "value": "JP"
+                        },
+                        {
+                            "name": "LAN",
+                            "value": "LAN"
+                        },
+                        {
+                            "name": "LAS",
+                            "value": "LAS"
+                        },
+                        {
+                            "name": "NA",
+                            "value": "NA"
+                        },
+                        {
+                            "name": "OCE",
+                            "value": "OCE"
+                        },
+                        {
+                            "name": "PBE",
+                            "value": "PBE"
+                        },
+                        {
+                            "name": "RU",
+                            "value": "RU"
+                        },
+                        {
+                            "name": "TR",
+                            "value": "TR"
+                        }
+                    ]
+                }
+            },
+            "spectatorType": {
+                "label": "Spectator Options",
+                "description": "Allow Spectators to join your matches",
+                "isRequired": true,
+                "defaultValue": "NONE",
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "No Spectators",
+                            "value": "NONE"
+                        },
+                        {
+                            "name": "Lobby Only",
+                            "value": "LOBBYONLY"
+                        },
+                        {
+                            "name": "All/Public",
+                            "value": "ALL"
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 61,
+        "videogameId": 1095,
+        "name": "Fortnite Free-for-all",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 62,
+        "videogameId": 45,
+        "name": "Gears of War 5v5",
+        "description": "Standard 5v5 ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    261,
+                    262,
+                    263,
+                    264,
+                    265,
+                    266,
+                    267
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1
+            ],
+            "gameSetup": false,
+            "characterSelectCount": 1,
+            "pickSideBeforeMap": {
+                "1": "Team A",
+                "2": "Team B"
+            },
+            "stageSelectAfterStrike": true,
+            "stageSelectOverride": true,
+            "oneCharacterForTeam": true,
+            "matchSetupOnly": true,
+            "matchSetup": true,
+            "banTerm": "ban"
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 63,
+        "videogameId": 1015,
+        "name": "NBA2K18 Standard",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": 1,
+        "cardLimit": null,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 64,
+        "videogameId": 936,
+        "name": "Duel Links",
+        "description": "Ruleset for Duel Links",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": {
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None",
+                            "value": 0
+                        },
+                        {
+                            "name": "Upload Deck Image",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 65,
+        "videogameId": 718,
+        "name": "PUBG Free-for-all",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 67,
+        "videogameId": 718,
+        "name": "PUBG Head-to-head",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 68,
+        "videogameId": 1095,
+        "name": "Fortnite Head-to-head",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 69,
+        "videogameId": 2147,
+        "name": "Ring Of Elysium Head-to-head",
+        "description": "Current default head to head ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 70,
+        "videogameId": 2147,
+        "name": "Ring Of Elysium Free-for-all",
+        "description": "Current Default FFA ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard"
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 71,
+        "videogameId": 2079,
+        "name": "Icons: Combat Arena Standard Ruleset",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "stages": {
+                "neutral": [
+                    280,
+                    281,
+                    282,
+                    283,
+                    284
+                ],
+                "counterpick": []
+            },
+            "gameSetup": 1,
+            "additionalFlags": {
+                "useMDSR": true,
+                "disableBans": 3
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 72,
+        "videogameId": 43,
+        "name": "Official Brood War Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    269,
+                    290,
+                    410,
+                    411,
+                    409
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "additionalFlags": {
+                "firstStriker": 1
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 73,
+        "videogameId": 1969,
+        "name": "Slap City Standard Ruleset",
+        "description": "This is the current default ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "strikeOrder": [
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    292,
+                    293,
+                    294
+                ],
+                "counterpick": [
+                    295,
+                    296,
+                    297
+                ]
+            },
+            "gameSetup": 1,
+            "additionalFlags": {
+                "stageSelectAfterStrike": true,
+                "useMDSR": true,
+                "ignoreBlind": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 74,
+        "videogameId": 2054,
+        "name": "Mario Tennis Aces Simple Mode",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    301,
+                    300,
+                    298,
+                    302,
+                    303
+                ],
+                "counterpick": [
+                    299,
+                    304
+                ]
+            },
+            "gameSetup": 1,
+            "additionalFlags": {
+                "firstStriker": 1,
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 75,
+        "videogameId": 44087,
+        "name": "Overwatch Free-for-all",
+        "description": "Free-for-all ruleset to be used for Overwatch Deathmatch",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 76,
+        "videogameId": 2774,
+        "name": "Call of Duty: Black Ops 4 Free-for-all",
+        "description": "Call of Duty Free-for-all",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 77,
+        "videogameId": 2774,
+        "name": "Call of Duty: Black Ops 4 Head to Head",
+        "description": "Call of Duty Head to Head",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 79,
+        "videogameId": 193,
+        "name": "ARMS Standard",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    258,
+                    243,
+                    244,
+                    259,
+                    239
+                ],
+                "counterpick": [
+                    260,
+                    241
+                ]
+            },
+            "additionalFlags": {
+                "stageSelectAfterStrike": true,
+                "banCount": 2,
+                "characterSelectAfterStageSelect": true,
+                "blindAfterStageSelect": true,
+                "firstStriker": 1
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 80,
+        "videogameId": 327,
+        "name": "Splatoon 2 Standard Ruleset",
+        "description": "This is the current default ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 81,
+        "videogameId": 1386,
+        "name": "SWT Ruleset",
+        "description": "Official ruleset for Smash World Tour",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    397,
+                    387,
+                    378
+                ],
+                "counterpick": [
+                    348,
+                    353,
+                    407,
+                    484
+                ]
+            },
+            "additionalFlags": {
+                "useDSR": true,
+                "banCount": 2
+            },
+            "gameSetup": true,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 82,
+        "videogameId": 1386,
+        "name": "2GG Ruleset",
+        "description": "This is the current default ruleset by 2GG",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    387,
+                    378,
+                    397
+                ],
+                "counterpick": [
+                    348
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": false,
+                "banCount": 2
+            },
+            "gameSetup": true,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 83,
+        "videogameId": 1386,
+        "name": "Basic Ruleset - No Stages",
+        "description": "Basic ruleset, only characters, no stages",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": 1,
+        "cardLimit": null,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 84,
+        "videogameId": 3161,
+        "name": "MTG Arena",
+        "description": "Default ruleset for MTG Arena",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": {
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None",
+                            "value": 0
+                        },
+                        {
+                            "name": "Upload Deck Image",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": null,
+        "cardLimit": 30,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": true,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 85,
+        "videogameId": 13,
+        "name": "Custom",
+        "description": null,
+        "isDefault": false,
+        "gameMode": 1,
+        "settings": {
+            "deckRestrictions": {
+                "legendaryLimit": 1
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "classSelection": true
+            }
+        },
+        "eventSettings": {
+            "classSelectionCount": {
+                "label": "Class Count",
+                "description": "Number of classes a user must select.",
+                "isRequired": true,
+                "defaultValue": 4,
+                "component": "FormsyInputElement",
+                "componentProps": {
+                    "type": "number"
+                }
+            },
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how users must display their decks.",
+                "isRequired": true,
+                "defaultValue": 2,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None - Class Selection Only",
+                            "value": 0
+                        },
+                        {
+                            "name": "User Input",
+                            "value": 2
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 0,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "decksPerClass": {
+                "label": "Decks Per Class",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsyInputElement",
+                "componentProps": {
+                    "type": "number",
+                    "inputProps": {
+                        "min": 1,
+                        "max": 10
+                    }
+                }
+            },
+            "requirePrimaryDeck": {
+                "label": "Require Primary Deck",
+                "description": "Require the player to specify a primary deck",
+                "isRequired": true,
+                "defaultValue": true,
+                "component": "FormsyCheckbox",
+                "componentProps": {
+                    "type": "number"
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 86,
+        "videogameId": 1386,
+        "name": "GENESIS 2022 Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCount": 2,
+                "useGenesisDSR": true
+            },
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    387,
+                    378,
+                    397
+                ],
+                "counterpick": [
+                    484,
+                    348
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 87,
+        "videogameId": 1969,
+        "name": "Slap City No Stage Striking",
+        "description": "Stage striking left up to chat",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 89,
+        "videogameId": 30,
+        "name": "StarCraft II Free-for-all",
+        "description": "Current Default FFA ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 90,
+        "videogameId": 3465,
+        "name": "Twitch Rivals Ruleset",
+        "description": "A custom ruleset for the Twitch Rivals events.",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 91,
+        "videogameId": 1386,
+        "name": "Frostbite 2020 Ruleset",
+        "description": "Smash Ultimate Ruleset for Frostbite 2020",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    387,
+                    378,
+                    397
+                ],
+                "counterpick": [
+                    348,
+                    353,
+                    407
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "noStageBanOnWin": true,
+                "useMDSR": true
+            },
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": null,
+        "cardLimit": 30,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": 25,
+        "allowCharacterDupes": true,
+        "classSelectionCount": 1,
+        "decksPerClass": 3,
+        "requirePrimaryDeck": true,
+        "deckExternalLinkRegex": null,
+        "id": 92,
+        "videogameId": 13,
+        "name": "Specialist",
+        "description": "A single-class format, Specialist requires players to bring three decks of the same class. One deck is designated as primary, and the secondary and tertiary decks are then built around that, sharing at least 25 cards with the primary deck.",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "classSelection": true
+            }
+        },
+        "eventSettings": {
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how players must display their decks.",
+                "isRequired": true,
+                "defaultValue": 2,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None - Class Selection Only",
+                            "value": 0
+                        },
+                        {
+                            "name": "User Input",
+                            "value": 2
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 0,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 93,
+        "videogameId": 2165,
+        "name": "Pax Arena Ruleset",
+        "description": "Ruleset for PAX Arena",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 94,
+        "videogameId": 3465,
+        "name": "Apex Legends Free-for-all - Squads",
+        "description": "A free-for-all format for Apex Legends",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 95,
+        "videogameId": 3465,
+        "name": "Apex Legends Head-to-head",
+        "description": "A head-to-head format for Apex Legends",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 96,
+        "videogameId": 3200,
+        "name": "Mortal Kombat 11 Ruleset",
+        "description": "The default Mortal Kombat 11 ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "blindBeforeAll": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 97,
+        "videogameId": 865,
+        "name": "Halo 5 Race Runner Ruleset",
+        "description": "Race Runner Ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "allowedReportingModes": "",
+            "autoReportingConfig": {
+                "streamWatchType": "mixer",
+                "sessionStartBuffer": 600,
+                "sessionEndBuffer": 60,
+                "reportingBuffer": 300,
+                "sessionReuseBuffer": 300,
+                "gameAPI": "Halo5API"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 98,
+        "videogameId": 1386,
+        "name": "Evo 2019 Ruleset",
+        "description": "Smash Ultimate Ruleset for Evo 2019",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    378,
+                    387,
+                    397
+                ],
+                "counterpick": [
+                    348,
+                    353,
+                    406,
+                    407
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "useMDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 99,
+        "videogameId": 10,
+        "name": "League of Legends Race Runner Ruleset",
+        "description": "Race Runner Ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "allowedReportingModes": "",
+            "autoReportingConfig": {
+                "streamWatchType": "mixer",
+                "sessionStartBuffer": 600,
+                "sessionEndBuffer": 60,
+                "reportingBuffer": 300,
+                "sessionReuseBuffer": 300,
+                "gameAPI": "riot-games-api"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 100,
+        "videogameId": 791,
+        "name": "Paladins Race Runner Ruleset",
+        "description": "Race Runner Ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "allowedReportingModes": "",
+            "autoReportingConfig": {
+                "streamWatchType": "mixer",
+                "sessionStartBuffer": 600,
+                "sessionEndBuffer": 60,
+                "reportingBuffer": 300,
+                "sessionReuseBuffer": 300,
+                "gameAPI": "PaladinsAPI"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 104,
+        "videogameId": 2555,
+        "name": "Halo 3: MCC Free-for-all - Solos",
+        "description": "FFA Ruleset for Halo 3: Master Chief Collection",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 105,
+        "videogameId": 2555,
+        "name": "Halo 3: MCC Head-to-head",
+        "description": "A head-to-head format for Halo 3: Master Chief Collection",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 106,
+        "videogameId": 3428,
+        "name": "DOTA 2 Auto Chess Free-for-all",
+        "description": "FFA Ruleset for DOTA 2 Auto Chess",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 107,
+        "videogameId": 3428,
+        "name": "DOTA 2 Auto Chess Head-to-head",
+        "description": "A head-to-head format for DOTA 2 Auto Chess",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 108,
+        "videogameId": 33594,
+        "name": "Teamfight Tactics Free-for-all",
+        "description": "FFA Ruleset for Teamfight Tactics",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 109,
+        "videogameId": 33594,
+        "name": "Teamfight Tactics Head-to-head",
+        "description": "A head-to-head format for Teamfight Tactics",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 110,
+        "videogameId": 33595,
+        "name": "Dota Underlords Free-for-all",
+        "description": "FFA Ruleset for Dota Underlords",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 111,
+        "videogameId": 33595,
+        "name": "Dota Underlords Head-to-head",
+        "description": "A head-to-head format for Dota Underlords",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 112,
+        "videogameId": 2054,
+        "name": "Mario Tennis Aces Standard Mode",
+        "description": "2019 Standard Mode Ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    298,
+                    299,
+                    300,
+                    301,
+                    303
+                ],
+                "counterpick": [
+                    302,
+                    304
+                ]
+            },
+            "gameSetup": true,
+            "additionalFlags": {
+                "firstStriker": 1,
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 113,
+        "videogameId": 33577,
+        "name": "Crash Team Racing Nitro-Fueled Free-for-all",
+        "description": "FFA Ruleset for Crash Team Racing Nitro-Fueled",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 114,
+        "videogameId": 3465,
+        "name": "Mixer Apex Legends Race Runner Ruleset",
+        "description": "Race Runner Ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "allowedReportingModes": "",
+            "autoReportingConfig": {
+                "streamWatchType": "mixer",
+                "sessionStartBuffer": 600,
+                "sessionEndBuffer": 60,
+                "reportingBuffer": 300,
+                "sessionReuseBuffer": 300,
+                "gameAPI": "WatchForAPI"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 115,
+        "videogameId": 1386,
+        "name": "Shine 2019 Ruleset",
+        "description": "Smash Ultimate Ruleset for Shine 2019",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    378,
+                    387,
+                    397
+                ],
+                "counterpick": [
+                    348,
+                    407
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "useMDSR": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 116,
+        "videogameId": 33754,
+        "name": "Chess Rush Free-for-all",
+        "description": "FFA Ruleset for Chess Rush",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 117,
+        "videogameId": 33754,
+        "name": "Chess Rush Head-to-head",
+        "description": "A head-to-head format for Chess Rush",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 118,
+        "videogameId": 1095,
+        "name": "Mixer WatchForAPI Race Runner",
+        "description": "Race Runner Ruleset",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "allowedReportingModes": "",
+            "autoReportingConfig": {
+                "streamWatchType": "mixer",
+                "sessionStartBuffer": 1200,
+                "sessionEndBuffer": 300,
+                "reportingBuffer": 300,
+                "sessionReuseBuffer": 300,
+                "gameAPI": "WatchForAPI"
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": 1,
+        "cardLimit": 30,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 119,
+        "videogameId": 33638,
+        "name": "TEPPEN",
+        "description": "TEPPEN Base Ruleset with Deck Support",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "classSelection": true
+            }
+        },
+        "eventSettings": {
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how players must display their decks.",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "None",
+                            "value": 0
+                        },
+                        {
+                            "name": "Upload Deck Image",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 120,
+        "videogameId": 3465,
+        "name": "Apex Legends H2H with WatchFor Reporting",
+        "description": "Proprietary Mixer Ruleset integrating the WatchFor API",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "reportingApi": "WatchForAPI"
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 121,
+        "videogameId": 1095,
+        "name": "Fortnite H2H with WatchFor Reporting",
+        "description": "Proprietary Mixer Ruleset integrating the WatchFor API",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "reportingApi": "WatchForAPI"
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 122,
+        "videogameId": 31,
+        "name": "Standard - No Stages",
+        "description": "Basic Ruleset for Overwatch with no Stage Striking",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "additionalFlags": {
+                "ignoreCharacters": true,
+                "pickSideAfterMap": {
+                    "1": "Blue (Defend)",
+                    "2": "Red (Attack)"
+                }
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": 1,
+        "cardLimit": null,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 124,
+        "videogameId": 342,
+        "name": "Pokemon TCG Online",
+        "description": "Pokemon TCG Online ruleset",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": {
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how players must display their decks.",
+                "isRequired": true,
+                "defaultValue": 3,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Players enter a link to their deck on an external site",
+                            "value": 3
+                        },
+                        {
+                            "name": "Disable decks",
+                            "value": 0
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 125,
+        "videogameId": 1386,
+        "name": "Syndicate 2019 Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    387,
+                    311,
+                    378,
+                    328,
+                    353
+                ],
+                "counterpick": [
+                    397,
+                    348
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": false,
+                "banCount": 2
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 126,
+        "videogameId": 1386,
+        "name": "GOML Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    378,
+                    387,
+                    397,
+                    328
+                ],
+                "counterpick": [
+                    348,
+                    407
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": 1,
+        "cardLimit": null,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 127,
+        "videogameId": 34062,
+        "name": "Legends of Runeterra",
+        "description": "Legends of Runeterra ruleset",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": {
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how players must display their decks.",
+                "isRequired": true,
+                "defaultValue": 3,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Players enter a link to their deck on an external site",
+                            "value": 3
+                        },
+                        {
+                            "name": "Disable decks",
+                            "value": 0
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 128,
+        "videogameId": 287,
+        "name": "DBFZ No Character Select",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "ignoreCharacters": true,
+            "characterSelectCount": 3,
+            "uniqueCharacters": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 129,
+        "videogameId": 1386,
+        "name": "Collision Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    378,
+                    387,
+                    484,
+                    328
+                ],
+                "counterpick": [
+                    397
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 130,
+        "videogameId": 2,
+        "name": "PMBR Recommended",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    92,
+                    116,
+                    121,
+                    105,
+                    130
+                ],
+                "counterpick": [
+                    100,
+                    102,
+                    125,
+                    98,
+                    111
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "useMDSR": true,
+                "chooseCharacterBeforeStageSelect": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 131,
+        "videogameId": 33602,
+        "name": "PMBR Recommended",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    418,
+                    442,
+                    447,
+                    431,
+                    456
+                ],
+                "counterpick": [
+                    426,
+                    428,
+                    451,
+                    424,
+                    437
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "useMDSR": true,
+                "chooseCharacterBeforeStageSelect": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 132,
+        "videogameId": 33823,
+        "name": "Call of Duty: Mobile Head to Head",
+        "description": "Call of Duty Head to Head",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 133,
+        "videogameId": 33823,
+        "name": "Call of Duty: Mobile Free-for-all",
+        "description": "Call of Duty Free-for-all",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 134,
+        "videogameId": 33528,
+        "name": "GRID Free-for-all",
+        "description": "GRID Free-for-all",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 135,
+        "videogameId": 34176,
+        "name": "Call of Duty: Warzone Head to Head",
+        "description": "Call of Duty Head to Head",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 136,
+        "videogameId": 34176,
+        "name": "Call of Duty: Warzone Free-for-all",
+        "description": "Call of Duty Free-for-all",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 137,
+        "videogameId": 1095,
+        "name": "Fortnite Dreamhack Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": {
+            "ffaPointConfig": [
+                {
+                    "type": "map",
+                    "field": "placement",
+                    "config": {
+                        "map": {
+                            "1": 60,
+                            "2": 53,
+                            "3": 49,
+                            "4": 47,
+                            "5": 46,
+                            "6": 45,
+                            "7": 44,
+                            "8": 43,
+                            "9": 42,
+                            "10": 41,
+                            "11": 40,
+                            "12": 39,
+                            "13": 38,
+                            "14": 37,
+                            "15": 36,
+                            "16": 35,
+                            "17": 34,
+                            "18": 33,
+                            "19": 32,
+                            "20": 31,
+                            "21": 30,
+                            "22": 29,
+                            "23": 28,
+                            "24": 27,
+                            "25": 26,
+                            "26": 25,
+                            "27": 24,
+                            "28": 23,
+                            "29": 22,
+                            "30": 21,
+                            "31": 20,
+                            "32": 19,
+                            "33": 18,
+                            "34": 17,
+                            "35": 16,
+                            "36": 15,
+                            "37": 14,
+                            "38": 13,
+                            "39": 12,
+                            "40": 11,
+                            "41": 10,
+                            "42": 9,
+                            "43": 8,
+                            "44": 7,
+                            "45": 6,
+                            "46": 5,
+                            "47": 4,
+                            "48": 3,
+                            "49": 2,
+                            "50": 1
+                        }
+                    }
+                },
+                {
+                    "type": "multiply",
+                    "field": "kills",
+                    "config": {
+                        "multiplier": 5
+                    }
+                }
+            ]
+        },
+        "expand": []
+    },
+    {
+        "id": 138,
+        "videogameId": 1,
+        "name": "Rollback Rumble Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    5,
+                    11,
+                    15,
+                    19,
+                    25
+                ],
+                "counterpick": [
+                    20
+                ]
+            },
+            "additionalFlags": {
+                "disableBans": 3,
+                "useMDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 139,
+        "videogameId": 1386,
+        "name": "The Box Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    397,
+                    378,
+                    387
+                ],
+                "counterpick": [
+                    348,
+                    407
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "useDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 140,
+        "videogameId": 1969,
+        "name": "SCO Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    293,
+                    294,
+                    292,
+                    482,
+                    483
+                ],
+                "counterpick": [
+                    295
+                ]
+            },
+            "additionalFlags": {
+                "disableBans": 3,
+                "useDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 141,
+        "videogameId": 1386,
+        "name": "Naifu Wars Ruleset",
+        "description": "Smash Ultimate ruleset used by Naifu Wars",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    378,
+                    387,
+                    397,
+                    328
+                ],
+                "counterpick": [
+                    406,
+                    407,
+                    348,
+                    353
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 3,
+                "useDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 142,
+        "videogameId": 1386,
+        "name": "Small Battlefield Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    387,
+                    378,
+                    484
+                ],
+                "counterpick": [
+                    348,
+                    353,
+                    407,
+                    397
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 3,
+                "useDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 143,
+        "videogameId": 1386,
+        "name": "The Box (SBF Edition)",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    378,
+                    387,
+                    397
+                ],
+                "counterpick": [
+                    348,
+                    407,
+                    484
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2,
+                "useDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 144,
+        "videogameId": 35033,
+        "name": "Tony Hawk's Pro Skater 1+2 Free-for-all",
+        "description": "Tony Hawk's Pro Skater 1+2 Free-for-all",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 145,
+        "videogameId": 34863,
+        "name": "Rushdown Revolt Standard",
+        "description": "Rushdown Revolt Standard Head to Head Ruleset",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    489,
+                    490,
+                    491,
+                    493,
+                    494
+                ],
+                "counterpick": [
+                    492,
+                    495,
+                    508
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": true,
+                "banCount": 2
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 146,
+        "videogameId": 2054,
+        "name": "Simple Doubles",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    298,
+                    301,
+                    303,
+                    299
+                ],
+                "counterpick": []
+            },
+            "additionalFlags": {
+                "disableBans": true,
+                "stageSelectAfterStrike": true,
+                "firstStriker": 1
+            },
+            "strikeOrder": [
+                2
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 148,
+        "videogameId": 35367,
+        "name": "Free-for-all",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 151,
+        "videogameId": 1386,
+        "name": "Frame Perfect Series",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    387,
+                    378,
+                    397,
+                    407,
+                    353
+                ],
+                "counterpick": [
+                    484,
+                    406,
+                    318,
+                    401,
+                    399,
+                    348,
+                    497
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 3,
+                "useMDSR": true
+            },
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 153,
+        "videogameId": 88,
+        "name": "PC Beta",
+        "description": "Ruleset for PC Beta",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    208,
+                    274,
+                    498,
+                    233,
+                    496
+                ],
+                "counterpick": [
+                    276,
+                    246,
+                    277
+                ],
+                "strikeOrder": [
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "additionalFlags": [],
+            "gameSetup": true
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 154,
+        "videogameId": 35957,
+        "name": "Eternal Return: Black Survival Free-for-all",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 155,
+        "videogameId": 1386,
+        "name": "Syndicate Doubles Ruleset",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    397,
+                    311,
+                    377,
+                    328,
+                    353
+                ],
+                "counterpick": [
+                    416,
+                    348
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": false,
+                "banCount": 2
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 159,
+        "videogameId": 16729,
+        "name": "Pinball FX3 Free-for-all",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 160,
+        "videogameId": 88,
+        "name": "Modified Recommended Ruleset (PC, 5 starters)",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    208,
+                    274,
+                    498,
+                    233,
+                    496
+                ],
+                "counterpick": [
+                    276,
+                    277,
+                    246,
+                    247
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": true,
+                "banCount": 0,
+                "banCountByMaxGames": {
+                    "3": 3,
+                    "5": 2
+                }
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 161,
+        "videogameId": 88,
+        "name": "Community Recommended Ruleset (PC)",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                3,
+                2
+            ],
+            "stages": {
+                "neutral": [
+                    208,
+                    274,
+                    498,
+                    233,
+                    496,
+                    247
+                ],
+                "counterpick": [
+                    276,
+                    277,
+                    246
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": true,
+                "banCount": 0,
+                "banCountByMaxGames": {
+                    "3": 3,
+                    "5": 2
+                }
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 162,
+        "videogameId": 88,
+        "name": "Community Recommended Ruleset (Consoles)",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    208,
+                    274,
+                    233,
+                    496,
+                    247
+                ],
+                "counterpick": [
+                    276,
+                    277,
+                    246
+                ]
+            },
+            "additionalFlags": {
+                "useMDSR": true,
+                "banCount": 0,
+                "banCountByMaxGames": {
+                    "3": 2,
+                    "5": 1
+                }
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 163,
+        "videogameId": 1386,
+        "name": "Wario's Smash Down",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    484,
+                    387,
+                    397
+                ],
+                "counterpick": [
+                    378,
+                    497,
+                    407,
+                    348
+                ]
+            },
+            "additionalFlags": {
+                "useDSR": true,
+                "banCount": 3
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 164,
+        "videogameId": 1386,
+        "name": "MDVA Classic",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    328,
+                    311,
+                    387,
+                    378,
+                    397
+                ],
+                "counterpick": [
+                    348,
+                    353,
+                    407
+                ]
+            },
+            "additionalFlags": {
+                "useDSR": false,
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 165,
+        "videogameId": 34915,
+        "name": "Demo Friendly Stage List (Europe)",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    504,
+                    506,
+                    502,
+                    499,
+                    507
+                ],
+                "counterpick": [
+                    503,
+                    500
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 166,
+        "videogameId": 34915,
+        "name": "Frame Perfect Series (USA)",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    504,
+                    500,
+                    502,
+                    499,
+                    501
+                ],
+                "counterpick": [
+                    506,
+                    505
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 167,
+        "videogameId": 34915,
+        "name": "Japanese Stage List",
+        "description": "",
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameSetup": true,
+            "gameMode": 1,
+            "strikeOrder": [
+                1,
+                1,
+                1
+            ],
+            "stages": {
+                "neutral": [
+                    504,
+                    502,
+                    499,
+                    501
+                ],
+                "counterpick": [
+                    506,
+                    505
+                ]
+            },
+            "additionalFlags": {
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 168,
+        "videogameId": 34161,
+        "name": "Free Fire Free-for-all",
+        "description": "",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 169,
+        "videogameId": 1,
+        "name": "LEVO Ruleset",
+        "description": "DSR except first stage",
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "type": "standard",
+            "gameMode": 1,
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    5,
+                    19,
+                    15,
+                    25,
+                    11
+                ],
+                "counterpick": [
+                    20
+                ]
+            },
+            "additionalFlags": {
+                "useLEVOmDSR": true
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 170,
+        "videogameId": 37843,
+        "name": "Financial Modeling Free-for-all",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 171,
+        "videogameId": 1,
+        "name": "Melee Doubles",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    20,
+                    19,
+                    5,
+                    25,
+                    15
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "additionalFlags": {
+                "useMDSR": true,
+                "disableBans": 3
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 172,
+        "videogameId": 1386,
+        "name": "Community CUP",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    328,
+                    397,
+                    378,
+                    387
+                ],
+                "counterpick": [
+                    497,
+                    484,
+                    407,
+                    348
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ],
+            "additionalFlags": {
+                "useDSR": true,
+                "banCount": 2
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 173,
+        "videogameId": 1386,
+        "name": "Wanted Online - Northern Cave",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    484,
+                    328,
+                    407,
+                    378,
+                    387,
+                    353,
+                    397,
+                    497
+                ]
+            },
+            "strikeOrder": [
+                3,
+                4,
+                1
+            ],
+            "additionalFlags": {
+                "banCount": 3
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 174,
+        "videogameId": 1386,
+        "name": "Wanted Online - Kalos League",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "stages": {
+                "neutral": [
+                    311,
+                    484,
+                    328,
+                    407,
+                    378,
+                    387,
+                    353,
+                    397,
+                    348
+                ]
+            },
+            "strikeOrder": [
+                3,
+                4,
+                1
+            ],
+            "additionalFlags": {
+                "banCount": 3
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 175,
+        "videogameId": 22254,
+        "name": "Official Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 176,
+        "videogameId": 38949,
+        "name": "Competitive Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": false,
+            "additionalFlags": {
+                "ignoreCharacters": true
+            }
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 177,
+        "videogameId": 1386,
+        "name": "Charles Stage List",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "useMDSR": true,
+                "banCount": 1
+            },
+            "stages": {
+                "neutral": [
+                    311,
+                    484,
+                    387,
+                    397,
+                    328
+                ],
+                "counterpick": [
+                    331
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 178,
+        "videogameId": 1800,
+        "name": "Free-for-all",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": {
+            "type": "standard",
+            "gameMode": 2
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 179,
+        "videogameId": 33602,
+        "name": "Default",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 180,
+        "videogameId": 39281,
+        "name": "Standard Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "chooseCharacterBeforeStageSelect": true,
+                "firstStriker": 1,
+                "useMDSR": true,
+                "banCountByMaxGames": {
+                    "3": 2,
+                    "5": 1
+                }
+            },
+            "stages": {
+                "neutral": [
+                    509,
+                    518,
+                    511,
+                    512,
+                    550
+                ],
+                "counterpick": [
+                    551,
+                    552,
+                    519
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 181,
+        "videogameId": 1386,
+        "name": "Experimental Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCountByMaxGames": {
+                    "3": 3,
+                    "5": 2
+                },
+                "useDSR": true
+            },
+            "stages": {
+                "neutral": [
+                    311,
+                    484,
+                    387,
+                    328,
+                    397
+                ],
+                "counterpick": [
+                    378,
+                    407,
+                    513,
+                    348
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 182,
+        "videogameId": 40325,
+        "name": "Competitive Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "selectFromAllStages": true,
+                "chooseCharacterBeforeStageSelect": true
+            },
+            "stages": {
+                "neutral": [
+                    522,
+                    523,
+                    525,
+                    526,
+                    527,
+                    528,
+                    529,
+                    530,
+                    531,
+                    532,
+                    533,
+                    534,
+                    535,
+                    536,
+                    537,
+                    538,
+                    539,
+                    540,
+                    558,
+                    559,
+                    560,
+                    561,
+                    562,
+                    563,
+                    564,
+                    565,
+                    566,
+                    567
+                ]
+            },
+            "strikeOrder": [
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 183,
+        "videogameId": 34245,
+        "name": "Standard Ruleset",
+        "description": null,
+        "isDefault": true,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": [],
+            "stages": {
+                "neutral": [
+                    514,
+                    515,
+                    516,
+                    517
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 184,
+        "videogameId": 39281,
+        "name": "CG 2v2 Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCountByMaxGames": {
+                    "3": 1,
+                    "5": 0
+                },
+                "useMDSR": true
+            },
+            "stages": {
+                "neutral": [
+                    509,
+                    510,
+                    511,
+                    512,
+                    518
+                ],
+                "counterpick": []
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 185,
+        "videogameId": 1969,
+        "name": "2022 Standard Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCount": 2,
+                "useDSR": true
+            },
+            "stages": {
+                "neutral": [
+                    293,
+                    294,
+                    292,
+                    483,
+                    482
+                ],
+                "counterpick": [
+                    520,
+                    295,
+                    521
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "type": "deck",
+        "cardDupeLimit": null,
+        "deckLimit": 1,
+        "cardLimit": null,
+        "maxOverlap": null,
+        "minOverlapWithPrimary": null,
+        "allowCharacterDupes": false,
+        "classSelectionCount": null,
+        "decksPerClass": null,
+        "requirePrimaryDeck": null,
+        "deckExternalLinkRegex": null,
+        "id": 186,
+        "videogameId": 40908,
+        "name": "Yu-Gi-Oh! Master Duel",
+        "description": "Yu-Gi-Oh! Master Duel ruleset",
+        "isDefault": true,
+        "gameMode": 1,
+        "settings": [],
+        "eventSettings": {
+            "deckDeadlineBehavior": {
+                "label": "Deck Deadline Behavior",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Remove Entrant From Bracket",
+                            "value": 0
+                        },
+                        {
+                            "name": "Do Not Remove Entrant",
+                            "value": 1
+                        }
+                    ]
+                }
+            },
+            "deckUploadMethod": {
+                "label": "Deck Upload Method",
+                "description": "Defines how players must display their decks.",
+                "isRequired": true,
+                "defaultValue": 1,
+                "component": "FormsySelectElement",
+                "componentProps": {
+                    "options": [
+                        {
+                            "name": "Disable decks",
+                            "value": 0
+                        },
+                        {
+                            "name": "Players upload images of their deck",
+                            "value": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "expand": []
+    },
+    {
+        "id": 187,
+        "videogameId": 5682,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 188,
+        "videogameId": 4743,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 189,
+        "videogameId": 22254,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 190,
+        "videogameId": 33335,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 191,
+        "videogameId": 39281,
+        "name": "CG 1v1 Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "useDSR": true,
+                "banCount": 1
+            },
+            "stages": {
+                "neutral": [
+                    509,
+                    511,
+                    518
+                ],
+                "counterpick": [
+                    512,
+                    510,
+                    519
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 192,
+        "videogameId": 1386,
+        "name": "Panda Cup Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "useDSR": true,
+                "banCount": 2
+            },
+            "stages": {
+                "neutral": [
+                    378,
+                    387,
+                    397,
+                    311,
+                    328
+                ],
+                "counterpick": [
+                    348,
+                    484,
+                    353
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 193,
+        "videogameId": 1386,
+        "name": "EU Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCount": 3,
+                "chooseCharacterBeforeStageSelect": true
+            },
+            "stages": {
+                "neutral": [
+                    311,
+                    484,
+                    328,
+                    407,
+                    378,
+                    387,
+                    397,
+                    348,
+                    513
+                ]
+            },
+            "strikeOrder": [
+                3,
+                4,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 194,
+        "videogameId": 40325,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 195,
+        "videogameId": 38859,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 196,
+        "videogameId": 40849,
+        "name": "MegaVersus Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "0": "uniqueTeamCharacters",
+                "1": "selectFromAllStages",
+                "banCount": 2
+            },
+            "stages": {
+                "neutral": [
+                    544,
+                    545,
+                    546,
+                    555,
+                    548,
+                    549
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 197,
+        "videogameId": 40849,
+        "name": "Warner Bros MVS Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "0": "uniqueTeamCharacters",
+                "1": "chooseCharacterBeforeStageSelect",
+                "useDSR": true,
+                "banCount": 2
+            },
+            "stages": {
+                "neutral": [
+                    544,
+                    545,
+                    546,
+                    547,
+                    548,
+                    549,
+                    553,
+                    554
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 198,
+        "videogameId": 45115,
+        "name": "FFA",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 2,
+        "settings": null,
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 199,
+        "videogameId": 39281,
+        "name": "Community Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCountByMaxGames": {
+                    "3": 2,
+                    "5": 1
+                },
+                "useMDSR": true
+            },
+            "stages": {
+                "neutral": [
+                    550,
+                    512,
+                    518,
+                    509,
+                    511
+                ],
+                "counterpick": [
+                    519,
+                    551,
+                    552
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 200,
+        "videogameId": 40849,
+        "name": "Warner Bros MVS 2v2 Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "0": "uniqueTeamCharacters",
+                "1": "chooseCharacterBeforeStageSelect",
+                "useDSR": true,
+                "banCount": 2
+            },
+            "stages": {
+                "neutral": [
+                    544,
+                    545,
+                    546,
+                    547,
+                    548,
+                    549,
+                    553,
+                    554,
+                    555
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 203,
+        "videogameId": 15,
+        "name": "Brawlhalla Singles",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "selectFromAllStages": true,
+                "disableBans": true
+            },
+            "stages": {
+                "neutral": [
+                    268,
+                    279,
+                    415,
+                    460,
+                    541,
+                    543,
+                    556
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 204,
+        "videogameId": 15,
+        "name": "Brawlhalla Doubles",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "selectFromAllStages": true,
+                "disableBans": true
+            },
+            "stages": {
+                "neutral": [
+                    268,
+                    415,
+                    460,
+                    541,
+                    543,
+                    556,
+                    557
+                ]
+            },
+            "strikeOrder": [
+                1,
+                2,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    },
+    {
+        "id": 206,
+        "videogameId": 46120,
+        "name": "Standard Ruleset",
+        "description": null,
+        "isDefault": false,
+        "type": "standard",
+        "gameMode": 1,
+        "settings": {
+            "gameSetup": true,
+            "additionalFlags": {
+                "banCount": 3
+            },
+            "stages": {
+                "neutral": [
+                    568,
+                    569,
+                    570,
+                    571,
+                    572,
+                    573,
+                    574
+                ]
+            },
+            "strikeOrder": [
+                1,
+                1,
+                1,
+                2,
+                1
+            ]
+        },
+        "eventSettings": null,
+        "expand": []
+    }
+]

--- a/src/ScoreManager.py
+++ b/src/ScoreManager.py
@@ -1,3 +1,137 @@
+
+
+# The current score of the match, as well as individual games, are managed by the ScoreManager ; the Scoreboard widget owns a ScoreManager instance
+# When the score changes in the ScoreManager, it is reflected in the state (by OnScoreChanged)
+# When the score is changed in the UI, instead of directly changing the state, the scoreboard widget informs the ScoreManager of the change (via OnScoreUIChanged)
+# When an external source attemps to change the score (auto-update or stage strike app), instead of directly changing the value if the UI,
+# we call ScoreManager.CommandScoreChange, which changes the score in the UI.  
+# Note that CommandScoreChange calls OnScoreChanged to update the state with the new data, then updates the UI, which calls OnScoreUIChanged, which calls OnScoreChanged a second time.
+# This is because there doesn't seem to be a safe way to make a difference between a code-induced change and an user-made change in the UI. I'm starting to hate Qt. 
+# (It isn't a problem anyway, as OnScoreChanged will check for differences and see that there isn't any -> doing nothing)
+
+# The ScoreManager *can* track individual games, when the information it receives allows it to ; but it may as well stop tracking them. 
+
+# Example 1 : The score is manually changed in the UI
+# - ScoreManager.OnScoreUIChanged is called with the new score
+# - Calls ScoreManager.OnScoreChanged
+# - Change self.score
+# - If the difference with the previous score is 1 (or -1), add a game (with no info) or remove one
+# - If the difference was greater, forget the games, we are now in score only mode
+# - The state is updated
+
+# Example 2 : data is received from start.gg, with chars and stage : 
+# - ScoreManager.CommandScoreChange is called with all the data. It updates self.games with it, as well as the score; OnScoreChanged is called, updates the state
+# - ScoreManager.CommandScoreChange also changes the values in the score widgets
+# - This (unfortunately) triggers the valueChanged signal, which calls ScoreManager.OnScoreChanged (see TSHScoreboardWidget.py:356)
+# - ScoreManager.OnScoreChanged sees that nothing changed since the last time we changed the score (as that was during the CommandScoreChange call)
+
+# REGARDING THE STAGE STRIKE WEB APP (SSWA)
+# It should be possible to do what we want to do here without really touching the way the SSWA works, but i think this is a good occasion to try doing so. 
+# My proposal is : 
+# - When the Web server tries to update the score :
+#   - IF the "allow sswa to change score setting" is true, call ScoreManager.ReportGame directly (without using any method of TSHScoreboardWidget)
+#   - In that case, IF the new "keep score updated in the sswa" setting is also true, send a message to the sswa with the new score. 
+# - Add a "Sync SSWA", which forces the synchronization. The information sent here include the score but also who won last (useful for stage strike).
+#   If that information is not known (we are in score-only mode or the last game has no winner), the user is prompted for it before the sync message is sent. 
+# - Currently, from what i understand, the SSWA doesn't know the exact order of previous games (it knows who won on which stages, but not in which order). We should change that
+# - Maybe when we receive an update from the SSWA and the data it holds doesn't match ours (different scores, or same score but different stages), a warning should be displayed,
+#   with the option of overwriting the ScoreManager's data OR to sync the stage strike app instead
+
+from .StateManager import StateManager
+
+
+class ScoreManager:
+    def __init__(self, parent) -> None:
+        self.scoreboardNumber = parent.scoreboardNumber
+        self.parent = parent
+        self.games = []
+        self.Reset()
+        
+    def Reset(self):
+        self.games = []
+        self.score = [0, 0]
+        
+    def Swap(self):
+        temp = self.score[0]
+        self.score[0] = self.score[1]
+        self.score[1] = temp
+        
+        for game in self.games:
+            if game and game["winner"]:
+                game["winner"] = 1 - game["winner"]    
+        
+    
+    def OnScoreUIChanged(self, team, value):
+        if self.score[team] == value: 
+            #If the new value is already the one we know, nothing to do (it's most likely because the change was done by the ScoreManager itself)
+            return
+        self.score[team] = value
+        StateManager.BlockSaving()
+        self.OnScoreChanged(team)
+        StateManager.ReleaseSaving()
+          
+    #if team is given we only update the score for that team in the state 
+    def OnScoreChanged(self, team = -1):
+        if team > -1:
+            #update just the score for the given team
+            StateManager.Set(f"score.{self.scoreboardNumber}.team.${team + 1}.score", self.score[team])
+            pass
+        else:
+            #Update EVERYTHING in the state
+            pass
+        
+    def OnGamesChanged(self):
+        
+        #recalculate the score
+        #only if it changed : 
+        StateManager.BlockSaving()
+        self.OnScoreChanged()
+        self.UpdateScoreUI()
+        StateManager.ReleaseSaving()
+    
+    def ReportGame(self, winner, p1Char, p2Char, stage):
+        #if we are in score only mode, we just increment the score 
+        #else : 
+        
+        self.games.append({
+            winner: winner,
+            p1Char: p1Char,
+            p2Char: p2Char,
+            stage: stage
+        })
+        self.OnGamesChanged()
+    
+    # We probably received data from startgg 
+    def ChangeGames(self, games):
+        #Process the games data
+        self.OnGamesChanged()
+    
+    def CommandScoreChange(self, team, change):
+        self.score[team] += change
+        self.UpdateScoreUI(team)
+        pass      
+                
+    def UpdateScoreUI(self, team = -1):
+        if team < 0:
+            self.UpdateScoreUI(0)
+            self.UpdateScoreUI(1)
+        else:
+            self.parent.SetScore(team, self.score[team])
+                
+    def EditGamesUI(self):
+        #Opens the UI allowing the user to edit each game. 
+        #I still don't know if the modifications take effect as you do them or when pressing a Save button (like on start.gg) (we need to think about performances tho)
+        pass
+    
+    def ReportGameUI(self):
+        #Opens the UI allowing the user to report a game
+        #display a warning if we are in score only mode
+        self.ReportGame(None, None, None, None)
+        pass
+    
+    
+
+#FRENCH VERSION OF THE NOTES (SAME AS THE BEGINNING OF THIS FILE I JUST COULDNT BRING MYSELF TO DELETE THEM BECAUSE SOME DETAILS MAY HAVE BEEN LOST IN TRANSLATION)
 # Le score du match,ainsi que les games, sont contenu dans le ScoreManager, propriété du Scoreboard.  
 # Pour l'appli stage strike : 
 # - Quand elle envoie un "x won", on ajoute une game avec les infos données (stage en gros)
@@ -20,45 +154,3 @@
 # Mode "score only", où on ne connait pas les games individuelles.
 # - On entre dans ce mode si on change le score manuellement dans les spinners
 # - Si on entre dans l'interface des games dans ce mode, on a juste un bouton qui propose de remettre le score à une valeur qui correspond aux games
-
-# CU1 : les joueurs ont fail sur l'appli, on veut corriger
-# - Si SSWA->TSH désactivé : on report les games 
-
-# Idée de GENIE : en fait ScoreManager est une class parente de TSHScoreboardWidget
-
-class ScoreManager:
-    def __init__(self, scoreboardNumber) -> None:
-        self.scoreboardNumber = scoreboardNumber
-        self.Reset()
-        
-    def Reset(self):
-        self.games = []
-        self.p1Score = 0
-        self.p2Score = 0
-        
-    def ReportGame(self, winner, p1Char, p2Char, stage):
-        pass
-    
-    def Swap(self):
-        temp = self.p1Score
-        self.p1Score = self.p2Score
-        self.p2Score = temp
-        
-        for game in self.games:
-            if game and game["winner"]:
-                game["winner"] = 1 - game["winner"]
-          
-    def SetScore():
-        pass
-    
-    def SetScoreExt():
-        #edit the score containers
-        pass      
-                
-    def EditGamesUI(self):
-        #Opens the UI allowing the user to edit each game
-        pass
-    
-    def ReportGameUI(self):
-        #Opens the UI allowing the yser to report a game
-        pass

--- a/src/ScoreManager.py
+++ b/src/ScoreManager.py
@@ -1,0 +1,64 @@
+# Le score du match,ainsi que les games, sont contenu dans le ScoreManager, propriété du Scoreboard.  
+# Pour l'appli stage strike : 
+# - Quand elle envoie un "x won", on ajoute une game avec les infos données (stage en gros)
+# - Quand l'appli envoie une update de score, elle demande le score actuel, pour se mettre à jour (setting pour désactiver ça)
+# - En + du setting actuel qui autorise l'appli stage strike à changer le score, un setting qui détemine si mettre le score à jour sur TSh le change dans l'appli. 
+# UI additionnelle : 
+# - Bouton "report game" : affiche un dialogue permettant de report une game (who won, chars, stage, final game ?). Report une game déclenche une modif startgg
+# - Bouton "games" : affiche un dialogue listant les games, et permettant de les éditer
+# - Bouton "modif startgg" (potentiellement dans l'UI de gestion des games ?) : update le score sur startgg
+# - Peut être boutons x won dans le scoreboard directement ?
+# - Bouton "update web app score" pour forcer une update du score sur l'app
+# Pour le scoreboard : 
+# SOLUTION 1 : Changer le score du ScoreManager sauvegarde le score dans le state ;
+# Quand le score est modifié depuis le scoreboard, il modifie le ScoreManager : calcul de la différence avec le score précédent du joueur concerné  
+# -> Si positif, ajout de x games (sans infos)  
+# -> Si négatif, retrait des x dernières games 
+# SOLUTION 2 : Changer le contenu des spinners change le state ; changer le ScoreManager change le contenu des spinners (donc changement du state)
+
+# Autre possibilité : 
+# Mode "score only", où on ne connait pas les games individuelles.
+# - On entre dans ce mode si on change le score manuellement dans les spinners
+# - Si on entre dans l'interface des games dans ce mode, on a juste un bouton qui propose de remettre le score à une valeur qui correspond aux games
+
+# CU1 : les joueurs ont fail sur l'appli, on veut corriger
+# - Si SSWA->TSH désactivé : on report les games 
+
+# Idée de GENIE : en fait ScoreManager est une class parente de TSHScoreboardWidget
+
+class ScoreManager:
+    def __init__(self, scoreboardNumber) -> None:
+        self.scoreboardNumber = scoreboardNumber
+        self.Reset()
+        
+    def Reset(self):
+        self.games = []
+        self.p1Score = 0
+        self.p2Score = 0
+        
+    def ReportGame(self, winner, p1Char, p2Char, stage):
+        pass
+    
+    def Swap(self):
+        temp = self.p1Score
+        self.p1Score = self.p2Score
+        self.p2Score = temp
+        
+        for game in self.games:
+            if game and game["winner"]:
+                game["winner"] = 1 - game["winner"]
+          
+    def SetScore():
+        pass
+    
+    def SetScoreExt():
+        #edit the score containers
+        pass      
+                
+    def EditGamesUI(self):
+        #Opens the UI allowing the user to edit each game
+        pass
+    
+    def ReportGameUI(self):
+        #Opens the UI allowing the yser to report a game
+        pass

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import *
 from qtpy.QtCore import *
 from qtpy import uic
 from typing import List
+from src import ScoreManager
 
 from src.TSHSelectSetWindow import TSHSelectSetWindow
 
@@ -36,6 +37,8 @@ class TSHScoreboardWidget(QWidget):
         super().__init__(*args)
 
         self.scoreboardNumber = scoreboardNumber
+
+        self.scoreManager = ScoreManager()
 
         StateManager.Set(f"score.{self.scoreboardNumber}", {})
         StateManager.Set(f"score.{self.scoreboardNumber}.last_sets.1", {})

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -1310,14 +1310,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation>Set laden</translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation>aktuelles Stream-Set laden</translation>
     </message>
@@ -1329,7 +1329,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1338,17 +1338,17 @@ p, li { white-space: pre-wrap; }
         <translation>ACHTUNG</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation>Set von {0} laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation>User-Set {0} laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation>User-Set laden</translation>
     </message>
@@ -1433,14 +1433,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation></translation>
@@ -1545,12 +1545,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation>Thumbnail wurde erstellt:</translation>
     </message>

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -723,7 +723,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation>Charaktere pro Slot</translation>
     </message>
@@ -1269,67 +1269,67 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation>Spieler pro Team</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation>Thumbnail erstellen</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation>Klarname</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation>Twitter</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation>Staat/Region</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>Charaktere</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation>Pronomen</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation>Set laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation>aktuelles Stream-Set laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation>TEAM {0}</translation>
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1338,17 +1338,17 @@ p, li { white-space: pre-wrap; }
         <translation>ACHTUNG</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation>Set von {0} laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation>User-Set {0} laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation>User-Set laden</translation>
     </message>
@@ -1433,14 +1433,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation></translation>
@@ -1545,12 +1545,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation>Thumbnail wurde erstellt:</translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -718,7 +718,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -765,7 +765,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1092,76 +1092,76 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation type="unfinished"></translation>
@@ -1532,12 +1532,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -765,7 +765,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1133,14 +1133,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1151,17 +1151,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation type="unfinished"></translation>
@@ -1532,12 +1532,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -1319,14 +1319,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation>Cargar set</translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation>Cargar set actual desde el stream</translation>
     </message>
@@ -1338,7 +1338,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1347,17 +1347,17 @@ p, li { white-space: pre-wrap; }
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation>Cargar set de {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation>Cargar set de usuario ({0})</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation>Cargar set de usuario</translation>
     </message>
@@ -1456,14 +1456,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation></translation>
@@ -1568,12 +1568,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation>La miniatura se generó aquí:</translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -728,7 +728,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation>Personajes por jugador</translation>
     </message>
@@ -1278,67 +1278,67 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation>Jugadores por equipo</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation>Generar Miniatura</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation>Nombre Real</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation>Localidad</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>Personajes</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation>Pronombres</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation>Cargar set</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation>Cargar set actual desde el stream</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation>EQUIPO {0}</translation>
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1347,17 +1347,17 @@ p, li { white-space: pre-wrap; }
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation>Cargar set de {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation>Cargar set de usuario ({0})</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation>Cargar set de usuario</translation>
     </message>
@@ -1456,14 +1456,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation></translation>
@@ -1568,12 +1568,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation>La miniatura se generó aquí:</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -1157,7 +1157,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation>Nombre de personnages par joueur</translation>
     </message>
@@ -1235,7 +1235,7 @@ p, li { white-space: pre-wrap; }
         <translation>Stage</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation>Nombre de joueurs par équipe</translation>
     </message>
@@ -1244,32 +1244,32 @@ p, li { white-space: pre-wrap; }
         <translation>Générer la miniature</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation>Générer la miniature</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation>Charger un set</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation>Charger le set actuel du stream</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation>ÉQUIPE {0}</translation>
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1278,17 +1278,17 @@ p, li { white-space: pre-wrap; }
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation>Charger un set depuis {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation>Charger le set de l&apos;utilisateur {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation>Charger un set utilisateur</translation>
     </message>
@@ -1392,31 +1392,31 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation>Nom Réel</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation>Twitter</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation>Lieu</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>Personnages</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation>Pronoms</translation>
     </message>
@@ -1499,14 +1499,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>)</translation>
@@ -1615,12 +1615,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - Miniature</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation>La miniature a été enregistrée à l&apos;emplacement suivant :</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -1250,14 +1250,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation>Charger un set</translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation>Charger le set actuel du stream</translation>
     </message>
@@ -1269,7 +1269,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1278,17 +1278,17 @@ p, li { white-space: pre-wrap; }
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation>Charger un set depuis {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation>Charger le set de l&apos;utilisateur {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation>Charger un set utilisateur</translation>
     </message>
@@ -1499,14 +1499,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>)</translation>
@@ -1615,12 +1615,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - Miniature</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation>La miniature a été enregistrée à l&apos;emplacement suivant :</translation>
     </message>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
     <name>app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1104,7 +1104,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation>Personaggi per giocatore</translation>
     </message>
@@ -1178,76 +1178,76 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation>Generare la miniatura</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation type="unfinished">Nome legale</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>Personaggi</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation type="unfinished"></translation>
@@ -1500,12 +1500,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - Miniatura</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
     <name>app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1219,14 +1219,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,17 +1237,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation type="unfinished"></translation>
@@ -1500,12 +1500,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - Miniatura</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -1129,7 +1129,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation>各プレイヤーの使用キャラクター数</translation>
     </message>
@@ -1301,55 +1301,55 @@ p, li { white-space: pre-wrap; }
         <translation>ステージ</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation>各チームのプレイヤー数</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation>本名</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation>ツイッター</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation>本拠地</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>使用キャラクター</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation>代名詞</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation>対戦データをロードする</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation>チーム{0}</translation>
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1358,29 +1358,29 @@ p, li { white-space: pre-wrap; }
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation>{0}から対戦データをロードする</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation>配信中の対戦データをロードする</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation>サムネイルを作成する</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation>ユーザーの対戦データ({0})をロードする</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation>ユーザーの対戦データをロードする</translation>
     </message>
@@ -1459,14 +1459,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>)</translation>
@@ -1571,12 +1571,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - サムネイル</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation>サムネイルはここに作成されました:</translation>
     </message>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -1337,7 +1337,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation>対戦データをロードする</translation>
     </message>
@@ -1349,7 +1349,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1358,14 +1358,14 @@ p, li { white-space: pre-wrap; }
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation>{0}から対戦データをロードする</translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation>配信中の対戦データをロードする</translation>
     </message>
@@ -1375,12 +1375,12 @@ p, li { white-space: pre-wrap; }
         <translation>サムネイルを作成する</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation>ユーザーの対戦データ({0})をロードする</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation>ユーザーの対戦データをロードする</translation>
     </message>
@@ -1459,14 +1459,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>)</translation>
@@ -1571,12 +1571,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - サムネイル</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation>サムネイルはここに作成されました:</translation>
     </message>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -1396,7 +1396,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation>Carregar set</translation>
     </message>
@@ -1408,7 +1408,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1417,14 +1417,14 @@ p, li { white-space: pre-wrap; }
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation>Carregar set do {0}</translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation>Carregar set atual do stream</translation>
     </message>
@@ -1434,12 +1434,12 @@ p, li { white-space: pre-wrap; }
         <translation>Gerar Thumbnail</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation>Carregar set do usuário ({0})</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation>Carregar set do usuário</translation>
     </message>
@@ -1522,14 +1522,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>)</translation>
@@ -1670,12 +1670,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation>A miniatura foi gerada aqui:</translation>
     </message>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -1176,7 +1176,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation>Personagens por jogador</translation>
     </message>
@@ -1356,7 +1356,7 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation>Jogadores por time</translation>
     </message>
@@ -1366,49 +1366,49 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation>Nome Real</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation>Local</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>Personagens</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation>Pronomes</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation>Carregar set</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation>TIME {0}</translation>
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1417,29 +1417,29 @@ p, li { white-space: pre-wrap; }
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation>Carregar set do {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation>Carregar set atual do stream</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation>Gerar Thumbnail</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation>Carregar set do usuário ({0})</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation>Carregar set do usuário</translation>
     </message>
@@ -1522,14 +1522,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>(</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>)</translation>
@@ -1670,12 +1670,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation>A miniatura foi gerada aqui:</translation>
     </message>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
     <name>app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1219,14 +1219,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,17 +1237,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>（</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>）</translation>
@@ -1500,12 +1500,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - 缩略图</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
     <name>app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1104,7 +1104,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1178,76 +1178,76 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>角色</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>（</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>）</translation>
@@ -1500,12 +1500,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation>TSH - 缩略图</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
     <name>app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="460"/>
+        <location filename="../TSHScoreboardWidget.py" line="471"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1219,14 +1219,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="197"/>
-        <location filename="../TSHScoreboardWidget.py" line="480"/>
+        <location filename="../TSHScoreboardWidget.py" line="491"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="207"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
-        <location filename="../TSHScoreboardWidget.py" line="739"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
+        <location filename="../TSHScoreboardWidget.py" line="750"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,17 +1237,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="473"/>
+        <location filename="../TSHScoreboardWidget.py" line="484"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="748"/>
+        <location filename="../TSHScoreboardWidget.py" line="759"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="752"/>
+        <location filename="../TSHScoreboardWidget.py" line="763"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>（</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="744"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>）</translation>
@@ -1500,12 +1500,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="436"/>
+        <location filename="../TSHScoreboardWidget.py" line="447"/>
         <source>TSH - Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="440"/>
+        <location filename="../TSHScoreboardWidget.py" line="451"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
     <name>app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="930"/>
-        <location filename="../TSHScoreboardWidget.py" line="457"/>
+        <location filename="../TSHScoreboardWidget.py" line="460"/>
         <location filename="../TournamentStreamHelper.py" line="122"/>
         <location filename="../TournamentStreamHelper.py" line="158"/>
         <location filename="../TournamentStreamHelper.py" line="566"/>
@@ -1104,7 +1104,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TSHCommentaryWidget.py" line="47"/>
         <location filename="../TSHPlayerListWidget.py" line="73"/>
         <location filename="../TSHBracketWidget.py" line="91"/>
-        <location filename="../TSHScoreboardWidget.py" line="110"/>
+        <location filename="../TSHScoreboardWidget.py" line="113"/>
         <source>Characters per player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1178,76 +1178,76 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="119"/>
+        <location filename="../TSHScoreboardWidget.py" line="122"/>
         <source>Players per team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="131"/>
+        <location filename="../TSHScoreboardWidget.py" line="134"/>
         <source>Generate Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="71"/>
-        <location filename="../TSHScoreboardWidget.py" line="163"/>
+        <location filename="../TSHScoreboardWidget.py" line="166"/>
         <source>Real Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="72"/>
-        <location filename="../TSHScoreboardWidget.py" line="164"/>
+        <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="73"/>
-        <location filename="../TSHScoreboardWidget.py" line="165"/>
+        <location filename="../TSHScoreboardWidget.py" line="168"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="74"/>
-        <location filename="../TSHScoreboardWidget.py" line="166"/>
+        <location filename="../TSHScoreboardWidget.py" line="169"/>
         <source>Characters</source>
         <translation>角色</translation>
     </message>
     <message>
         <location filename="../TSHCommentaryWidget.py" line="75"/>
-        <location filename="../TSHScoreboardWidget.py" line="167"/>
+        <location filename="../TSHScoreboardWidget.py" line="170"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="194"/>
-        <location filename="../TSHScoreboardWidget.py" line="477"/>
+        <location filename="../TSHScoreboardWidget.py" line="197"/>
+        <location filename="../TSHScoreboardWidget.py" line="480"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="204"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
-        <location filename="../TSHScoreboardWidget.py" line="736"/>
+        <location filename="../TSHScoreboardWidget.py" line="207"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
+        <location filename="../TSHScoreboardWidget.py" line="739"/>
         <source>Load current stream set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="273"/>
-        <location filename="../TSHScoreboardWidget.py" line="300"/>
+        <location filename="../TSHScoreboardWidget.py" line="276"/>
+        <location filename="../TSHScoreboardWidget.py" line="303"/>
         <source>TEAM {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="470"/>
+        <location filename="../TSHScoreboardWidget.py" line="473"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="745"/>
+        <location filename="../TSHScoreboardWidget.py" line="748"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="749"/>
+        <location filename="../TSHScoreboardWidget.py" line="752"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1388,14 +1388,14 @@ p, li { white-space: pre-wrap; }
     <name>punctuation</name>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="120"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>(</source>
         <translation>（</translation>
     </message>
     <message>
         <location filename="../TSHSelectSetWindow.py" line="121"/>
-        <location filename="../TSHScoreboardWidget.py" line="730"/>
+        <location filename="../TSHScoreboardWidget.py" line="733"/>
         <location filename="../TournamentStreamHelper.py" line="714"/>
         <source>)</source>
         <translation>）</translation>
@@ -1500,12 +1500,12 @@ p, li { white-space: pre-wrap; }
     <name>thumb_app</name>
     <message>
         <location filename="../TSHThumbnailSettingsWidget.py" line="928"/>
-        <location filename="../TSHScoreboardWidget.py" line="433"/>
+        <location filename="../TSHScoreboardWidget.py" line="436"/>
         <source>TSH - Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="437"/>
+        <location filename="../TSHScoreboardWidget.py" line="440"/>
         <source>The thumbnail has been generated here:</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Trying to make the scoreboard able to remember each game. This would most importantly allow us to fully report a set from TSH (#629). 

It is currently in a prototype state. A lot of areas need to be changed, most importantly
- The scoreboard widget
- The stage strike web server
- The code of the stage strike web app itself

I need your feedbacks and ideas on ... well, this whole mess ! 

The current score of the match, as well as individual games, are managed by the ScoreManager (new class) ; the Scoreboard widget owns a ScoreManager instance.
When the score changes in the ScoreManager, it is reflected in the state (by OnScoreChanged)
When the score is changed in the UI, instead of directly changing the state, the scoreboard widget informs the ScoreManager of the change (via OnScoreUIChanged)
When an external source attemps to change the score (auto-update or stage strike app), instead of directly changing the value if the UI,
we call ScoreManager.CommandScoreChange, which changes the score in the UI.  
Note that CommandScoreChange calls OnScoreChanged to update the state with the new data, then updates the UI, which calls OnScoreUIChanged, which calls OnScoreChanged a second time.
This is because there doesn't seem to be a safe way to make a difference between a code-induced change and an user-made change in the UI. I'm starting to hate Qt. 
(It isn't a problem anyway, as OnScoreChanged will check for differences and see that there isn't any -> doing nothing)

The ScoreManager *can* track individual games, when the information it receives allows it to ; but it may also stop tracking them ("score-only mode")

Example 1 : The score is manually changed in the UI
- ScoreManager.OnScoreUIChanged is called with the new score
- Calls ScoreManager.OnScoreChanged
- Change self.score
- If the difference with the previous score is 1 (or -1), add a game (with no info) or remove one
- If the difference was greater, forget the games, we are now in score only mode
- The state is updated

Example 2 : data is received from start.gg, with chars and stage : 
- ScoreManager.CommandScoreChange is called with all the data. It updates self.games with it, as well as the score; OnScoreChanged is called, updates the state
- ScoreManager.CommandScoreChange also changes the values in the score widgets
- This (unfortunately) triggers the valueChanged signal, which calls ScoreManager.OnScoreChanged (see TSHScoreboardWidget.py:356)
- ScoreManager.OnScoreChanged sees that nothing changed since the last time we changed the score (as that was during the CommandScoreChange call)

REGARDING THE STAGE STRIKE WEB APP (SSWA)
It should be possible to do what we want to do here without really touching the way the SSWA works, but i think this is a good occasion to try doing so. 
My proposal is : 
- When the Web server tries to update the score :
  - IF the "allow sswa to change score setting" is true, call ScoreManager.ReportGame directly (without using any method of TSHScoreboardWidget)
  - In that case, IF the new "keep score updated in the sswa" setting is also true, send a message to the sswa with the new score. 
- Add a "Sync SSWA", which forces the synchronization. The information sent here include the score but also who won last (useful for stage strike).
  If that information is not known (we are in score-only mode or the last game has no winner), the user is prompted for it before the sync message is sent. 
- Currently, from what i understand, the SSWA doesn't know the exact order of previous games (it knows who won on which stages, but not in which order). We should change that
- Maybe when we receive an update from the SSWA and the data it holds doesn't match ours (different scores, or same score but different stages), a warning should be displayed, with the option of overwriting the ScoreManager's data OR to sync the stage strike app instead

ADDITIONAL UI : what we need to add
- Single game reporting dialog (and the button to invoke it)
- All-games editing dialog (and the button to invoke it)
- "Update SSWA" button, to force the SSWA to sync with what TSH knows (with a dialog asking who won last game if the ScoreManager doesn't know)
- Possibly, some UI somewhere informing the user that the state we received from the SSWA doesn't match what the ScoreManager has

Prototype for the All-Games Editing UI (made using my favorite professional design software, LibreOffice Draw)
![image](https://github.com/joaorb64/TournamentStreamHelper/assets/30086846/8ce2f78a-bb65-48b5-81cd-e862790fc2e2)
