### PR TITLE
Adjust color dialog to be dark gray instead

### DIFF
--- a/src/TSHColorButton.py
+++ b/src/TSHColorButton.py
@@ -47,6 +47,7 @@ class TSHColorButton(QToolButton):
 
         '''
         dlg = QColorDialog(self)
+        dlg.setStyleSheet("* { background-color: rgb(41, 41, 41); }")
         if self._color:
             dlg.setCurrentColor(QColor(self._color))
 


### PR DESCRIPTION
Small one line addition to address the color picker background being the same as the current color selected.