### PR TITLE
include hacky python3.12 fix

### DIFF
--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -4,7 +4,7 @@ qtpy
 requests
 py7zr
 deepdiff
-pyqtdarktheme
+git+https://github.com/woopelderly/PyQtDarkTheme@python3.12
 Pillow
 Flask
 flask-cors


### PR DESCRIPTION
So qdarktheme is unmaintained, woo! It means that it doesn't support 3.12, but someone did a PR to fix compatibility. Down the road that branch itself should probably be forked and referenced from TSH instead, but for now this works.