### PR TITLE
Adding desktop.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ main.spec
 *.tmp
 logs/*
 Pipfile*
+
+desktop.ini


### PR DESCRIPTION
In Windows, you can customize the icon of a specific folder, which creates a desktop.ini file inside that folder. Since committing that file is usually not something you want, I added desktop.ini to .gitignore, so people can have their own customized folder icon for TSH without interacting with git.

Probably the most useless PR so far but i really like customized folder icons