### PR TITLE
Fix : the stream_queue layout ignored it's avatar display setting

### DIFF
--- a/layout/stream_queue/index.js
+++ b/layout/stream_queue/index.js
@@ -109,7 +109,7 @@ LoadEverything().then(() => {
 
         return `
             <div class = "p${t} team">
-                ${isTeams && !config.display.avatar ? "" : online_avatar_html(player, t)}
+                ${isTeams || !config.display.avatar ? "" : online_avatar_html(player, t)}
                 <div class = "flags">
                     ${ isTeams ? "" : 
                         (player.country.asset && config.display.country_flag ? `<div class='flag' style='background-image: url(../../${player.country.asset.toLowerCase()})'></div>` : "") + 


### PR DESCRIPTION
this PR changes exactly two characters in the code which makes me feel a bit stupid

In layout/stream_queue/settings.json, changing "display.avatar" to false did nothing (avatar still showed), which is fixed