### PR TITLE
Added sample layout for Rivals 2

### DIFF
--- a/layout/scoreboard/index.css
+++ b/layout/scoreboard/index.css
@@ -111,6 +111,11 @@ body {
   width: 480px;
 }
 
+.roa2 .player.container {
+  top: 0px;
+  height: 100px;
+  width: 750px;
+}
 
 .mk1 .player.container {
   top: 105px;
@@ -165,6 +170,11 @@ body {
   left: 248px;
 }
 
+.roa2 .p1.container {
+  left: 0px;
+  border-radius: 0px 0px var(--border-radius) 0px;
+}
+
 .mk1 .p1.container {
   left: 350px;
 }
@@ -211,6 +221,11 @@ body {
 
 .sf6 .p2.container {
   right: 248px;
+}
+
+.roa2 .p2.container {
+  right: 0px;
+  border-radius: 0px 0px 0px var(--border-radius);
 }
 
 .mk1 .p2.container {
@@ -262,6 +277,15 @@ body {
 }
 
 .sf6.offline .chips {
+  width: 450px;
+}
+
+.roa2 .chips {
+  top: 106px;
+  height: 32px;
+}
+
+.roa2.offline .chips {
   width: 450px;
 }
 
@@ -319,6 +343,11 @@ body {
   justify-content: left;
 }
 
+.roa2.offline .p1.chips {
+  left: 8px;
+  justify-content: left;
+}
+
 .mk1 .chip {
   height: 32px;
 }
@@ -371,6 +400,12 @@ body {
 }
 
 .sf6.offline .p2.chips {
+  left: unset;
+  right: 8px;
+  justify-content: right;
+}
+
+.roa2.offline .p2.chips {
   left: unset;
   right: 8px;
   justify-content: right;
@@ -458,6 +493,11 @@ body {
   height: 100%;
 }
 
+.roa2 .chip .text:not(.text_empty) {
+  font-size: 20px;
+  height: 100%;
+}
+
 .sf6.online .seed.chip .text:not(.text_empty) {
   margin: 0;
   border-radius: 0;
@@ -506,6 +546,11 @@ body {
 .sf6 .name_twitter .name {
   width: 100%;
   font-size: 30px;
+}
+
+.roa2 .name_twitter .name {
+  width: 100%;
+  font-size: 40px;
 }
 
 .mk1 .name_twitter .name {
@@ -704,6 +749,12 @@ body {
   top: 924px;
 }
 
+.roa2 .logo {
+  width: 80px;
+  height: 80px;
+  top: 130px;
+}
+
 .mk1 .logo {
   width: 80px;
   height: 80px;
@@ -792,6 +843,12 @@ body {
   height: 100%;
 }
 
+.roa2 .tournament_name {
+  font-size: 30px;
+  width: 100%;
+  height: 100%;
+}
+
 .fgc .info.container.top {
   top: 8px;
   height: 34px;
@@ -848,6 +905,20 @@ body {
   height: 30px;
 }
 
+
+.roa2 .info.container.top {
+  transform: unset;
+  top: unset;
+  left: unset;
+  right: 0px;
+  bottom: 0px;
+  width: 350px;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  height: 70px;
+}
+
 .info.container.bottom {
   top: 42px;
   left: 42px;
@@ -868,6 +939,11 @@ body {
 }
 
 .sf6 .phase {
+  font-size: 20px;
+  letter-spacing: 2px;
+}
+
+.roa2 .phase {
   font-size: 20px;
   letter-spacing: 2px;
 }
@@ -915,6 +991,15 @@ body {
   bottom: unset;
   transform: unset;
   left: 10px;
+}
+
+.roa2 .info.container.bottom {
+  bottom: unset;
+  top: 0px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  height: 40px;
+  width: 300px;
 }
 
 .arms .info.container.bottom {
@@ -1015,6 +1100,16 @@ body {
   width: 34px;
 }
 
+.roa2 .icon div:not(.text) {
+  height: 70px;
+  width: 70px;
+}
+
+.roa2 .character_container div:not(.text) {
+  height: 70px;
+  width: 70px;
+}
+
 .flags_container {
   display: flex;
   flex-direction: column;
@@ -1097,6 +1192,11 @@ body {
 
 .sf6 .score {
   font-size: 34px;
+}
+
+.roa2 .score {
+  height: 110px;
+  font-size: 50px;
 }
 
 .p1 .score {

--- a/layout/scoreboard/roa2.html
+++ b/layout/scoreboard/roa2.html
@@ -1,0 +1,63 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="../include/globals.js"></script>
+    <link rel="stylesheet" href="../main.css" />
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body class="fgc roa2 offline">
+    <div class="logo"></div>
+
+    <div class="anim_container_outer">
+      <div class="anim_container_inner">
+        <div class="info top container">
+          <div class="tournament_name"></div>
+          <div class="phase"></div>
+        </div>
+
+        <div class="p1 player container">
+          <div class="icon avatar"></div>
+          <div class="icon online_avatar"></div>
+          <div class="character_container"></div>
+          <div class="flagcountry"></div>
+          <div class="flagstate"></div>
+          <div class="sponsor_icon"></div>
+          <div class="name_twitter">
+            <div class="name"></div>
+          </div>
+          <div class="score"></div>
+        </div>
+        <div class="p2 player container">
+          <div class="icon avatar"></div>
+          <div class="icon online_avatar"></div>
+          <div class="character_container"></div>
+          <div class="flagcountry"></div>
+          <div class="flagstate"></div>
+          <div class="sponsor_icon"></div>
+          <div class="name_twitter">
+            <div class="name"></div>
+          </div>
+          <div class="score"></div>
+        </div>
+
+        <div class="info bottom container">
+          <div class="match"></div>
+        </div>
+
+        <div class="p1 chips">
+          <div class="seed chip"></div>
+          <div class="twitter chip"></div>
+          <div class="pronoun chip"></div>
+        </div>
+
+        <div class="p2 chips">
+          <div class="seed chip"></div>
+          <div class="twitter chip"></div>
+          <div class="pronoun chip"></div>
+        </div>
+      </div>
+    </div>
+
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -939,10 +939,8 @@ class TSHGameAssetManager(QObject):
                             else:
                                 metadata_title_locale = asset.get("metadata", {})[
                                     key].get("title", '')
-                            charFiles[assetKey]['metadata'][f"{
-                                key}"]["title"] = metadata_title_locale
-                            charFiles[assetKey]['metadata'][f"{
-                                key}"][f"value_en"] = metadata[key]
+                            charFiles[assetKey]['metadata'][f"{key}"]["title"] = metadata_title_locale
+                            charFiles[assetKey]['metadata'][f"{key}"][f"value_en"] = metadata[key]
                             if TSHLocaleHelper.exportLocale in asset.get("metadata", {})[key]["values"].get(characterCodename, {}).get("locale", {}).keys() or TSHLocaleHelper.exportLocale.split('-')[0] in asset.get("metadata", {})[key]["values"].get(characterCodename, {}).get("locale", {}).keys():
                                 try:
                                     metadata[key] = asset.get("metadata", {})[key]["values"].get(
@@ -950,8 +948,7 @@ class TSHGameAssetManager(QObject):
                                 except KeyError:
                                     metadata[key] = asset.get("metadata", {})[key]["values"].get(
                                         characterCodename, {}).get("locale", {})[TSHLocaleHelper.exportLocale.split('-')[0]]
-                            charFiles[assetKey]['metadata'][f"{
-                                key}"][f"value"] = metadata[key]
+                            charFiles[assetKey]['metadata'][f"{key}"][f"value"] = metadata[key]
 
                         # if len(metadata.keys()) > 0:
                         #     if str(skin) in metadata:

--- a/src/TournamentDataProvider/ChallongeDataProvider.py
+++ b/src/TournamentDataProvider/ChallongeDataProvider.py
@@ -103,8 +103,7 @@ class ChallongeDataProvider(TournamentDataProvider):
             slug = self.GetSlug()
 
             data = self.scraper.get(
-                f"https://challonge.com/en/search/tournaments.json?filters%5B&page=1&per=1&q={
-                    slug}",
+                f"https://challonge.com/en/search/tournaments.json?filters%5B&page=1&per=1&q={slug}",
 
             )
             logger.debug(data.text)
@@ -128,8 +127,7 @@ class ChallongeDataProvider(TournamentDataProvider):
                     finalData["startAt"] = dateutil.parser.parse(
                         dateElement.get("text"), fuzzy=True).timestamp()
             except Exception as e:
-                logger.error(f"Could not get tournament date: {
-                             traceback.format_exc()}")
+                logger.error(f"Could not get tournament date: {traceback.format_exc()}")
 
             participantsElement = next(
                 (d for d in details if d.get("icon") == "fa fa-users"), None)

--- a/test/test_eyesights.py
+++ b/test/test_eyesights.py
@@ -11,10 +11,10 @@ tested_assets = {
     "en1a": ["full"],
     "jackie": ["full"],
     "sdbz": ["base_files/icon","full"],
-    "sf6": ["base_files/icon", "full"],
-    "idols": ["base_files/icon", "full"],
+    "sf6": ["base_files/icon", "full", "art", "pixel_art", "hd_portrait", "pixel_art_restore", "cartoon", "chibi"],
+    "idols": ["base_files/icon", "full", "art"],
     "jojoasbr": ["full"],
-    "roa": ["base_files/icon", "full"],
+    "roa": ["full"],
     "avg2": ["full"],
     "umvc3": ["full"],
     "bh": ["full"],
@@ -22,7 +22,17 @@ tested_assets = {
     "ssmack": ["full"],
     "trotb": ["base_files/icon"],
     "nasb2": ["render"],
-    "rbff2": ["full"]
+    "rbff2": ["full"],
+    "tekken8": ["full"],
+    "vsav": ["full", "full_new"],
+    "doe": ["full"],
+    "rsubf": ["base_files/icon"],
+    "ffcotw": ["base_files/icon"],
+    "ostrikers": ["full", "art"],
+    "sfalpha2": ["base_files/icon"],
+    "sfalpha3": ["base_files/icon", "full"],
+    "cvs2": ["base_files/icon"],
+    "svc": ["base_files/icon"]
 }
 
 main_out_path = "../out/test"


### PR DESCRIPTION
- Added sample layout for Rivals 2
  - Example: ![Screenshot 2024-06-15 16-37-10](https://github.com/joaorb64/TournamentStreamHelper/assets/1964201/c5633918-05f6-4e15-ab0e-da6d6f48502c)
- Fixes to Python syntax