### PR TITLE
Option to force default team colors

### DIFF
--- a/layout/main.css
+++ b/layout/main.css
@@ -61,6 +61,8 @@
 
   --p1-sponsor-color: #ff7a6d;
   --p2-sponsor-color: #29b6f6;
+  --p1-score-bg-color: rgb(254, 54, 54);
+  --p2-score-bg-color: rgb(46, 137, 255);
   --p1-score-color: white;
   --p2-score-color: white;
 }

--- a/layout/scoreboard/index.js
+++ b/layout/scoreboard/index.js
@@ -260,7 +260,7 @@ LoadEverything().then(() => {
             }
           }
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_4by3/index.js
+++ b/layout/scoreboard_4by3/index.js
@@ -52,7 +52,7 @@ LoadEverything().then(() => {
 
       SetInnerHtml($(`.${team_id} .score`), String(team.score));
 
-      if(team.color) {
+      if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
         document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
       }
 

--- a/layout/scoreboard_JinTracker/index.js
+++ b/layout/scoreboard_JinTracker/index.js
@@ -222,7 +222,7 @@ LoadEverything().then(() => {
             );
             UpdateColor(player, t);
           }
-          if (team.color) {
+          if (team.color && !tsh_settings["forceDefaultScoreColors"]) {
             document
               .querySelector(":root")
               .style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
@@ -283,7 +283,7 @@ LoadEverything().then(() => {
           SetInnerHtml($(`.p${t + 1}.container .sponsor_icon`), "");
           SetInnerHtml($(`.p${t + 1} .score`), String(team.score));
           UpdateColorAlternate(player, t);
-          if (team.color) {
+          if (team.color && !tsh_settings["forceDefaultScoreColors"]) {
             document
               .querySelector(":root")
               .style.setProperty(`--p${t + 1}-score-bg-color`, team.color);

--- a/layout/scoreboard_WellySmash/index.js
+++ b/layout/scoreboard_WellySmash/index.js
@@ -110,7 +110,7 @@ LoadEverything().then(() => {
           );
 
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_artistic/index.js
+++ b/layout/scoreboard_artistic/index.js
@@ -154,7 +154,7 @@ LoadEverything().then(() => {
             );
           }
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }
@@ -255,7 +255,7 @@ LoadEverything().then(() => {
           `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
         );
         
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_mainstagy/index.js
+++ b/layout/scoreboard_mainstagy/index.js
@@ -165,7 +165,7 @@ LoadEverything().then(() => {
             `<div class='sponsor_logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
           );
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_pandastic/index.js
+++ b/layout/scoreboard_pandastic/index.js
@@ -155,7 +155,7 @@ LoadEverything().then(() => {
               `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
             );
           }
-          if(team.color) {
+          if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
             document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
           }
         }
@@ -237,7 +237,7 @@ LoadEverything().then(() => {
           $(`.p${t + 1}.container .sponsor-container`),
           `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
         );
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_simple/index.js
+++ b/layout/scoreboard_simple/index.js
@@ -145,7 +145,7 @@ LoadEverything().then(() => {
             `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
           );
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_topleft/index.js
+++ b/layout/scoreboard_topleft/index.js
@@ -143,7 +143,7 @@ LoadEverything().then(() => {
               `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
             );
           }
-          if(team.color) {
+          if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
             document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
           }
         }
@@ -230,7 +230,7 @@ LoadEverything().then(() => {
           `<div class='sponsor-logo' style='background-image: url(../../${player.sponsor_logo})'></div>`
         );
 
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_vgbootcampy/index.js
+++ b/layout/scoreboard_vgbootcampy/index.js
@@ -140,7 +140,7 @@ LoadEverything().then(() => {
               : `<div class='sponsor-logo' style=''></div>`
           );
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_vgbootcampy_classic/index.js
+++ b/layout/scoreboard_vgbootcampy_classic/index.js
@@ -140,7 +140,7 @@ LoadEverything().then(() => {
             SetInnerHtml($(`.p${t + 1}.twitter`), player.pronoun.toUpperCase());
           }
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_vgbootcampy_neo/index.js
+++ b/layout/scoreboard_vgbootcampy_neo/index.js
@@ -140,7 +140,7 @@ LoadEverything().then(() => {
             SetInnerHtml($(`.p${t + 1}.twitter`), player.pronoun.toUpperCase());
           }
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/scoreboard_vgbootcampy_waiting/index.js
+++ b/layout/scoreboard_vgbootcampy_waiting/index.js
@@ -108,7 +108,7 @@ LoadEverything().then(() => {
 
           SetInnerHtml($(`.p${t + 1}.score`), String(team.score));
         }
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }

--- a/layout/versus_screen/index.js
+++ b/layout/versus_screen/index.js
@@ -209,7 +209,7 @@ LoadEverything().then(() => {
           }
         }
 
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }
@@ -366,7 +366,7 @@ LoadEverything().then(() => {
           );
         }
 
-        if(team.color) {
+        if(team.color && !tsh_settings["forceDefaultScoreColors"]) {
           document.querySelector(':root').style.setProperty(`--p${t + 1}-score-bg-color`, team.color);
         }
       }


### PR DESCRIPTION
Added the "forceDefaultScoreColors" option for layout settings, which, when set to true, makes the layout ignore custom team colors exported by TSH (and use the default one, red and blue)