### PR TITLE
Added feature to differentiate between skin names and "alternate characters"

### DIFF
--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -644,8 +644,9 @@ class TSHGameAssetManager(QObject):
                 except:
                     logger.error(traceback.format_exc())
 
-                assetData["name"] = skin_name
-                assetData["en_name"] = skin_name_en
+                if skinNameData.get(skinIndex, {}).get("is_different_character", False):
+                    assetData["name"] = skin_name
+                    assetData["en_name"] = skin_name_en
 
                 item.setData(skin_name if skin_name else skinIndex,
                              Qt.ItemDataRole.EditRole)

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -1249,7 +1249,7 @@ def createFalseData(gameAssetManager: TSHGameAssetManager = None, used_assets: s
 
 
 def remove_special_chars(input_str: str):
-    invalid = '<>:"/\|?* '
+    invalid = '<>:"/\\|?* '
     for char in invalid:
         input_str = input_str.replace(char, "")
     return input_str


### PR DESCRIPTION
- Added feature to differentiate between skin names and "alternate characters"
  - "Alternate characters" are defined as a special skin which turns the character into a completely different character
  - Alternate character names are exported to the program output, while regular skin names are not
  - Skins are marked as alternate characters using the `is_different_character` attribute
- Fixed special character sequence for thumbnails