### PR TITLE
Fallback to local filesystem file if it exists

### DIFF
--- a/src/Helpers/TSHDirHelper.py
+++ b/src/Helpers/TSHDirHelper.py
@@ -1,7 +1,12 @@
-from os import path
 import sys
+from pathlib import Path
 
 is_in_bundle = getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
+current_dir = Path.cwd()
 
 def TSHResolve(filename):
-    return path.join(sys._MEIPASS if is_in_bundle else '.', filename)
+    fullPath = Path(current_dir, filename)
+    if not fullPath.exists() and is_in_bundle:
+        fullPath = Path(sys._MEIPASS, filename)
+
+    return str(fullPath.resolve())


### PR DESCRIPTION
In case there's anything I missed to #784 (e.g. OS-specific paths being different) merge this, otherwise feel free to close. Takes current working directory over bundle dir if there's a file that exists, or else falls back to bundle temp dir