### PR TITLE
Bugfixes and Features

### DIFF
--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -414,11 +414,12 @@ class TSHGameAssetManager(QObject):
                         except:
                             logger.error(traceback.format_exc())
 
+                    
                     StateManager.Set(f"game", {
                         "name": self.parent().selectedGame.get("name"),
                         "smashgg_id": self.parent().selectedGame.get("smashgg_game_id"),
                         "codename": self.parent().selectedGame.get("codename"),
-                        "logo": self.parent().selectedGame.get("path")+"/base_files/logo.png",
+                        "logo": self.parent().selectedGame.get("path", "")+"/base_files/logo.png",
                     })
 
                     self.parent().UpdateCharacterModel()

--- a/src/TSHTournamentInfoWidget.py
+++ b/src/TSHTournamentInfoWidget.py
@@ -182,6 +182,17 @@ class TSHTournamentInfoWidget(QDockWidget):
                         # Convert date into QDate object
                         d = QDate.fromString(local_date, "yyyy-MM-dd")
                         widget.setDate(d)
+                else:
+                    exceptions = ["endAt", "eventStartAt", "eventEndAt"]
+                    info = data.get(key)
+
+                    if key in exceptions and data.get(key) != "":
+                        unix_timestamp = float(data[key])
+                        local_datetime = time.strftime("%x", time.localtime(
+                            unix_timestamp))
+                        info = local_datetime
+                    
+                    StateManager.Set(f"tournamentInfo.{key}", info)
             except:
                 logger.error(traceback.format_exc())
                 SettingsManager.Set("TOURNAMENT_URL", '')

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -463,6 +463,15 @@ class WebServer(QThread):
         emit('load_player_from_tag', WebServer.actions.load_player_from_tag(
             scoreboardNumber, html.unescape(args.get('tag')), team, player, no_mains))
 
+    # Update bracket
+    @app.route('/set-tournament')
+    def set_tournament():
+        return WebServer.actions.load_tournament(request.args.get('url'))
+
+    @socketio.on('set_tournament')
+    def ws_set_tournament(message):
+        emit('set_tournament', WebServer.actions.load_tournament(request.args.get('url')))
+
     @app.route('/', defaults=dict(filename=None))
     @app.route('/<path:filename>', methods=['GET', 'POST'])
     @cross_origin()

--- a/src/TournamentDataProvider/StartGGDataProvider.py
+++ b/src/TournamentDataProvider/StartGGDataProvider.py
@@ -103,6 +103,12 @@ class StartGGDataProvider(TournamentDataProvider):
                 data, "data.event.tournament.shortSlug", "")
             finalData["startAt"] = deep_get(
                 data, "data.event.tournament.startAt", "")
+            finalData["endAt"] = deep_get(
+                data, "data.event.tournament.endAt", "")
+            finalData["eventStartAt"] = deep_get(
+                data, "data.event.startAt", "")
+            finalData["eventEndAt"] = deep_get(
+                data, "data.event.endAt", "")
         except:
             logger.error(traceback.format_exc())
 

--- a/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
@@ -8,6 +8,8 @@ query TournamentDataQuery($eventSlug: String!) {
     isOnline
     name
     numEntrants
+    startAt
+    endAt
     tournament {
         name
         shortSlug

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -674,6 +674,8 @@ class Window(QMainWindow):
         )
         TSHTournamentDataProvider.instance.signals.tournament_changed.connect(
             self.SetGame)
+        TSHTournamentDataProvider.instance.signals.tournament_url_update.connect(
+            self.Signal_GameChange)
 
         pre_base_layout.addLayout(base_layout)
         hbox.addWidget(self.gameSelect)
@@ -741,6 +743,11 @@ class Window(QMainWindow):
             "name") or self.gameSelect.itemText(i) == TSHGameAssetManager.instance.selectedGame.get("codename")), None)
         if index is not None:
             self.gameSelect.setCurrentIndex(index)
+    
+    def Signal_GameChange(self, url):
+        if url == "":
+            self.gameSelect.setCurrentIndex(0)
+            TSHGameAssetManager.instance.selectedGame = {}
 
     def UpdateUserSetButton(self):
         if SettingsManager.Get("StartGG_user"):

--- a/src/layout/TSHScoreboardScore.ui
+++ b/src/layout/TSHScoreboardScore.ui
@@ -13,7 +13,6 @@
   <property name="font">
    <font>
     <pointsize>8</pointsize>
-    <weight>75</weight>
     <bold>true</bold>
    </font>
   </property>
@@ -35,7 +34,6 @@
      <property name="font">
       <font>
        <pointsize>10</pointsize>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -53,7 +51,6 @@
           <property name="font">
            <font>
             <pointsize>8</pointsize>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -73,7 +70,6 @@
           <property name="font">
            <font>
             <pointsize>10</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -94,7 +90,6 @@
           <property name="font">
            <font>
             <pointsize>8</pointsize>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -114,7 +109,6 @@
           <property name="font">
            <font>
             <pointsize>10</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -138,7 +132,6 @@
           <property name="font">
            <font>
             <pointsize>8</pointsize>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -149,10 +142,15 @@
         </item>
         <item alignment="Qt::AlignLeft">
          <widget class="QSpinBox" name="best_of">
+          <property name="minimumSize">
+           <size>
+            <width>75</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="font">
            <font>
             <pointsize>10</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
             <kerning>true</kerning>
            </font>
@@ -166,7 +164,6 @@
         <property name="font">
          <font>
           <pointsize>8</pointsize>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -182,7 +179,6 @@
           <property name="font">
            <font>
             <pointsize>16</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -196,7 +192,6 @@
           <property name="font">
            <font>
             <pointsize>16</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>


### PR DESCRIPTION
- Addressed an issue in the Game Asset Manager that would happen when clearing a tournament.
- Made "Best Of" spinner bigger after some users had issues with the sizing cutting into the data and being unreadable.
- Added Event start and stop time exports at the request of Mathias for multi-day events (or online series' that go for weeks).
- Add web server/SocketIO capability to remotely set a tournament URL. (I know, I know, I'm way too late to the party on this, but it's here now)

This took me way to long to make due to the weird design of the Game Asset Manager, but hopefully this is a note that we need to simplify it more :)