### PR TITLE
Fix a strange case where round_division could be missing

### DIFF
--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -935,13 +935,14 @@ class TSHScoreboardWidget(QWidget):
                 # Is this Top 16 - Top ??? (even 128), if so...
                 # check if this isn't pools and isn't a qualifier
                 round_division = data.get("roundDivision", 0)
-                if data.get("isPools", False) is False and round_division > 6:
-                    original_str = tournament_phase.split(" - ")
-                    tournament_phase = TSHLocaleHelper.phaseNames.get("top_n", "Top {0}").format(round_division)
+                if round_division:
+                    if data.get("isPools", False) is False and round_division > 6:
+                        original_str = tournament_phase.split(" - ")
+                        tournament_phase = TSHLocaleHelper.phaseNames.get("top_n", "Top {0}").format(round_division)
 
-                    # Include "Bracket - XYZ" similar to if it's Pools
-                    if len(original_str) > 1:
-                        tournament_phase = f"{original_str[0]} - {tournament_phase}"
+                        # Include "Bracket - XYZ" similar to if it's Pools
+                        if len(original_str) > 1:
+                            tournament_phase = f"{original_str[0]} - {tournament_phase}"
 
                 self.scoreColumn.findChild(
                     QComboBox, "phase").setCurrentText(tournament_phase)


### PR DESCRIPTION
Fixes this strange error the leads to only the round name, and no other data loading.

```
Traceback (most recent call last):
  File "I:\TournamentStreamHelper\src\TSHScoreboardWidget.py", line 1075, in UpdateSetData
    self.ChangeSetData(data)
  File "I:\TournamentStreamHelper\src\TSHScoreboardWidget.py", line 938, in ChangeSetData
    if data.get("isPools", False) is False and round_division > 6:
                                               ^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

Other people have reported this issue as well (I suspect it was the same issue [here](https://discord.com/channels/1012284618457759755/1012285180989415434/1299887956986953810))