### PR TITLE
Various fixes

### DIFF
--- a/layout/include/globals.js
+++ b/layout/include/globals.js
@@ -632,9 +632,9 @@ async function CenterImageDo(element) {
               uncropped_edge.length == 0
             ) {
               if (zoom_x > zoom_y) {
-                minZoom = zoom_x * rescalingFactor;
+                minZoom = zoom_x * proportional_zoom * rescalingFactor;
               } else {
-                minZoom = zoom_y * rescalingFactor;
+                minZoom = zoom_y * proportional_zoom * rescalingFactor;
               }
             } else {
               if (
@@ -648,26 +648,69 @@ async function CenterImageDo(element) {
                 !uncropped_edge.includes("l") &&
                 !uncropped_edge.includes("r")
               ) {
-                minZoom = zoom_x * rescalingFactor;
+                minZoom = zoom_x * proportional_zoom * rescalingFactor;
               } else if (
                 !uncropped_edge.includes("u") &&
                 !uncropped_edge.includes("d")
               ) {
-                minZoom = zoom_y * rescalingFactor;
+                minZoom = zoom_y * proportional_zoom * rescalingFactor;
               } else {
                 minZoom = customZoom * proportional_zoom * rescalingFactor;
               }
             }
 
             if (scale_fill_x && !scale_fill_y) {
-              minZoom = zoom_x;
+              minZoom = zoom_x * proportional_zoom * rescalingFactor;
             } else if (scale_fill_y && !scale_fill_x) {
-              minZoom = zoom_y;
+              minZoom = zoom_y * proportional_zoom * rescalingFactor;
             } else if (scale_fill_x && scale_fill_y) {
               minZoom = Math.max(zoom_x, zoom_y);
             }
 
             zoom = Math.max(minZoom, customZoom * minZoom);
+
+            if (
+              !(!uncropped_edge ||
+              uncropped_edge == "undefined" ||
+              uncropped_edge.length == 0)
+            ) {
+              if (
+                (!uncropped_edge.includes("u") && !uncropped_edge.includes("d")) ||
+                (!uncropped_edge.includes("l") && !uncropped_edge.includes("r"))
+              ) {
+                let minZoomWidth = min_zoom*img.naturalWidth;
+                let minZoomHeight = min_zoom*img.naturalHeight;
+                let correctionRatio = 1.0;
+
+                if (
+                  (!uncropped_edge.includes("l") && !uncropped_edge.includes("r")) && (minZoomWidth != $(customElement).innerWidth())
+                ) {
+                  correctionRatio = $(customElement).innerWidth() / minZoomWidth;
+                  minZoomWidth = correctionRatio * minZoomWidth;
+                  minZoomHeight = correctionRatio * minZoomHeight;
+                  if (
+                    !(!uncropped_edge.includes("u") && !uncropped_edge.includes("d")) ||
+                    (!uncropped_edge.includes("u") && !uncropped_edge.includes("d") && minZoomHeight >= $(customElement).innerHeight())
+                  ) {
+                    zoom = zoom * correctionRatio
+                  }
+                }
+                
+                if (
+                  (!uncropped_edge.includes("u") && !uncropped_edge.includes("d")) && (minZoomHeight != $(customElement).innerHeight())
+                ) {
+                  correctionRatio = $(customElement).innerHeight() / minZoomHeight;
+                  minZoomWidth = correctionRatio * minZoomWidth;
+                  minZoomHeight = correctionRatio * minZoomHeight;
+                  if (
+                    !(!uncropped_edge.includes("l") && !uncropped_edge.includes("r")) ||
+                    (!uncropped_edge.includes("l") && !uncropped_edge.includes("r") && minZoomWidth >= $(customElement).innerWidth())
+                  ) {
+                    zoom = zoom * correctionRatio
+                  }
+                }
+              }
+            }
 
             // Cetering
             let xx = 0;

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -192,7 +192,7 @@ class TSHGameAssetManager(QObject):
                 for alternate in alternates:
                     if alternate.get("challonge_game_id"):
                         alternates_ids.append(
-                            str(alternate.get("smashgg_game_id")))
+                            str(alternate.get("challonge_game_id")))
                 result = str(id) in alternates_ids
             return (result)
 

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -322,24 +322,6 @@ class TSHGameAssetManager(QObject):
 
                                     packSkinMask[c][assetsKey].add(number)
 
-                                    # Get image dimensions
-                                    imgfile = QImageReader(
-                                        './user_data/games/'+game+'/'+assetsKey+'/'+f)
-
-                                    size = imgfile.size()
-
-                                    if not assetsKey in widths:
-                                        widths[assetsKey] = []
-
-                                    if size.width() != -1:
-                                        widths[assetsKey].append(size.width())
-
-                                    if not assetsKey in heights:
-                                        heights[assetsKey] = []
-
-                                    if size.height() != -1:
-                                        heights[assetsKey].append(
-                                            size.height())
                             logger.info("Character "+c+" has " +
                                         str(len(self.parent().skins[c]))+" skins")
 
@@ -348,10 +330,7 @@ class TSHGameAssetManager(QObject):
                             if assetsKey != "base_files" and assetsKey != "stage_icon":
                                 try:
                                     if len(widths.get(assetsKey, [])) > 0 and len(heights.get(assetsKey, [])) > 0:
-                                        gameObj["assets"][assetsKey]["average_size"] = {
-                                            "x": sum(widths[assetsKey])/len(widths[assetsKey]),
-                                            "y": sum(heights[assetsKey])/len(heights[assetsKey])
-                                        }
+                                        gameObj["assets"][assetsKey]["average_size"] = assetsObj.get("average_size")
                                 except:
                                     logger.error(traceback.format_exc())
 

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -496,7 +496,7 @@ class TSHScoreboardWidget(QWidget):
             matchString = TSHLocaleHelper.matchNames[key]
 
             try:
-                if "{0}" in matchString:
+                if "{0}" in matchString and ("qualifier" not in key):
                     for number in range(5):
                         if key == "best_of":
                             if self.scoreColumn.findChild(QComboBox, "match").findText(matchString.format(str(2*number+1))) < 0:

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -578,6 +578,9 @@ class TSHScoreboardWidget(QWidget):
                 msgBox.setInformativeText(str(e))
                 msgBox.setIcon(QMessageBox.Warning)
                 msgBox.exec()
+            for rm_path in [thumbnailPath, thumbnailPath.replace(".png", ".jpg"), thumbnailPath.replace(".png", "_desc.txt"), thumbnailPath.replace(".png", "_title.txt")]:
+                if os.path.exists(rm_path):
+                    os.remove(rm_path)
     
     def ToggleElements(self, action: QAction, elements):
         for pw in self.playerWidgets:

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -1096,7 +1096,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1204,7 +1204,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation>Assets werden heruntergeladen</translation>
     </message>

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -1388,7 +1388,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation>Set laden</translation>
     </message>
@@ -1439,17 +1439,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation>Set von {0} laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation>User-Set {0} laden</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation>User-Set laden</translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -1211,7 +1211,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,17 +1237,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -1095,7 +1095,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1343,7 +1343,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -1101,7 +1101,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1213,7 +1213,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation>Descargando archivos</translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -1397,7 +1397,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation>Cargar set</translation>
     </message>
@@ -1448,17 +1448,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation>Cargar set de {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation>Cargar set de usuario ({0})</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation>Cargar set de usuario</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -861,7 +861,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1166,7 +1166,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation>Téléchargement des ressources</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -1327,7 +1327,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation>Charger un set</translation>
     </message>
@@ -1372,17 +1372,17 @@ p, li { white-space: pre-wrap; }
         <translation>Le post a été envoyé sur le compte {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation>Charger un set depuis {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation>Charger le set de l&apos;utilisateur {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation>Charger un set utilisateur</translation>
     </message>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -1025,7 +1025,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation>Annulare</translation>
     </message>
@@ -1127,7 +1127,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -1297,7 +1297,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1323,17 +1323,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -943,7 +943,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1138,7 +1138,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation>アセットをダウンロードしています</translation>
     </message>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -1415,7 +1415,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation>対戦データをロードする</translation>
     </message>
@@ -1442,7 +1442,7 @@ p, li { white-space: pre-wrap; }
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation>{0}から対戦データをロードする</translation>
     </message>
@@ -1476,12 +1476,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation>ユーザーの対戦データ({0})をロードする</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation>ユーザーの対戦データをロードする</translation>
     </message>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -882,7 +882,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1185,7 +1185,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation>Baixando conteúdo do jogo</translation>
     </message>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -1474,7 +1474,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation>Carregar set</translation>
     </message>
@@ -1501,7 +1501,7 @@ p, li { white-space: pre-wrap; }
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation>Carregar set do {0}</translation>
     </message>
@@ -1535,12 +1535,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation>Carregar set do usuário ({0})</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation>Carregar set do usuário</translation>
     </message>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -1025,7 +1025,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1127,7 +1127,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -1297,7 +1297,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1323,17 +1323,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -1025,7 +1025,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../TournamentStreamHelper.py" line="875"/>
         <location filename="../TournamentStreamHelper.py" line="885"/>
         <location filename="../TSHAssetDownloader.py" line="306"/>
-        <location filename="../TSHAssetDownloader.py" line="470"/>
+        <location filename="../TSHAssetDownloader.py" line="468"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1127,7 +1127,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHAssetDownloader.py" line="305"/>
-        <location filename="../TSHAssetDownloader.py" line="469"/>
+        <location filename="../TSHAssetDownloader.py" line="467"/>
         <source>Downloading assets</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -1297,7 +1297,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardWidget.py" line="268"/>
-        <location filename="../TSHScoreboardWidget.py" line="596"/>
+        <location filename="../TSHScoreboardWidget.py" line="599"/>
         <source>Load set</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1323,17 +1323,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="590"/>
+        <location filename="../TSHScoreboardWidget.py" line="593"/>
         <source>Load set from {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="904"/>
+        <location filename="../TSHScoreboardWidget.py" line="907"/>
         <source>Load user set ({0})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardWidget.py" line="908"/>
+        <location filename="../TSHScoreboardWidget.py" line="911"/>
         <source>Load user set</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -380,13 +380,13 @@ def paste_image_matrix(thumbnail, path_matrix, max_size, paste_coordinates, eyes
                     correction_ratio = max_size[0] / minZoomWidth
                     minZoomWidth = minZoomWidth * correction_ratio
                     minZoomHeight = minZoomHeight * correction_ratio
-                    if (not (not 'u' in uncropped_edge and not 'd' in uncropped_edge)) or ((not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight > max_size[1]):
+                    if (not (not 'u' in uncropped_edge and not 'd' in uncropped_edge)) or ((not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight >= max_size[1]):
                         zoom = zoom * correction_ratio
                 if (not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight != max_size[1]:
                     correction_ratio = max_size[1] / minZoomHeight
                     minZoomWidth = minZoomWidth * correction_ratio
                     minZoomHeight = minZoomHeight * correction_ratio
-                    if (not (not 'l' in uncropped_edge and not 'r' in uncropped_edge)) or ((not 'l' in uncropped_edge and not 'r' in uncropped_edge) and minZoomWidth > max_size[0]):
+                    if (not (not 'l' in uncropped_edge and not 'r' in uncropped_edge)) or ((not 'l' in uncropped_edge and not 'r' in uncropped_edge) and minZoomWidth >= max_size[0]):
                         zoom = zoom * correction_ratio
             # print("zoom", zoom)
 

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -376,13 +376,13 @@ def paste_image_matrix(thumbnail, path_matrix, max_size, paste_coordinates, eyes
             if (not 'l' in uncropped_edge and not 'r' in uncropped_edge) or (not 'u' in uncropped_edge and not 'd' in uncropped_edge):
                 minZoomWidth = min_zoom*tmpWidth
                 minZoomHeight = min_zoom*tmpHeight
-                if (not 'l' in uncropped_edge and not 'r' in uncropped_edge) and minZoomWidth > max_size[0]:
+                if (not 'l' in uncropped_edge and not 'r' in uncropped_edge) and minZoomWidth != max_size[0]:
                     correction_ratio = max_size[0] / minZoomWidth
                     minZoomWidth = minZoomWidth * correction_ratio
                     minZoomHeight = minZoomHeight * correction_ratio
                     if (not (not 'u' in uncropped_edge and not 'd' in uncropped_edge)) or ((not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight > max_size[1]):
                         zoom = zoom * correction_ratio
-                if (not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight > max_size[1]:
+                if (not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight != max_size[1]:
                     correction_ratio = max_size[1] / minZoomHeight
                     minZoomWidth = minZoomWidth * correction_ratio
                     minZoomHeight = minZoomHeight * correction_ratio

--- a/src/thumbnail/main_generate_thumbnail.py
+++ b/src/thumbnail/main_generate_thumbnail.py
@@ -350,29 +350,44 @@ def paste_image_matrix(thumbnail, path_matrix, max_size, paste_coordinates, eyes
 
             if not uncropped_edge:
                 if zoom_x > zoom_y:
-                    min_zoom = zoom_x * rescaling_factor
+                    min_zoom = zoom_x * proportional_zoom * rescaling_factor
                 else:
-                    min_zoom = zoom_y * rescaling_factor
+                    min_zoom = zoom_y * proportional_zoom * rescaling_factor
             else:
                 if 'u' in uncropped_edge and 'd' in uncropped_edge and 'l' in uncropped_edge and 'r' in uncropped_edge:
                     min_zoom = customZoom * proportional_zoom * rescaling_factor
                 elif not 'l' in uncropped_edge and not 'r' in uncropped_edge:
-                    min_zoom = zoom_x * rescaling_factor
+                    min_zoom = zoom_x * proportional_zoom * rescaling_factor
                 elif not 'u' in uncropped_edge and not 'd' in uncropped_edge:
-                    min_zoom = zoom_y * rescaling_factor
+                    min_zoom = zoom_y * proportional_zoom * rescaling_factor
                 else:
                     min_zoom = customZoom * proportional_zoom * rescaling_factor
 
             global scale_fill_x, scale_fill_y
             # print("scale_fill", scale_fill_x, scale_fill_y)
             if scale_fill_x and not scale_fill_y:
-                min_zoom = zoom_x
+                min_zoom = zoom_x  * proportional_zoom * rescaling_factor
             elif scale_fill_y and not scale_fill_x:
-                min_zoom = zoom_y
+                min_zoom = zoom_y  * proportional_zoom * rescaling_factor
             elif scale_fill_x and scale_fill_y:
-                min_zoom = max(zoom_x, zoom_y)
+                min_zoom = max(zoom_x, zoom_y) * rescaling_factor
 
             zoom = max(min_zoom, customZoom * min_zoom)
+            if (not 'l' in uncropped_edge and not 'r' in uncropped_edge) or (not 'u' in uncropped_edge and not 'd' in uncropped_edge):
+                minZoomWidth = min_zoom*tmpWidth
+                minZoomHeight = min_zoom*tmpHeight
+                if (not 'l' in uncropped_edge and not 'r' in uncropped_edge) and minZoomWidth > max_size[0]:
+                    correction_ratio = max_size[0] / minZoomWidth
+                    minZoomWidth = minZoomWidth * correction_ratio
+                    minZoomHeight = minZoomHeight * correction_ratio
+                    if (not (not 'u' in uncropped_edge and not 'd' in uncropped_edge)) or ((not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight > max_size[1]):
+                        zoom = zoom * correction_ratio
+                if (not 'u' in uncropped_edge and not 'd' in uncropped_edge) and minZoomHeight > max_size[1]:
+                    correction_ratio = max_size[1] / minZoomHeight
+                    minZoomWidth = minZoomWidth * correction_ratio
+                    minZoomHeight = minZoomHeight * correction_ratio
+                    if (not (not 'l' in uncropped_edge and not 'r' in uncropped_edge)) or ((not 'l' in uncropped_edge and not 'r' in uncropped_edge) and minZoomWidth > max_size[0]):
+                        zoom = zoom * correction_ratio
             # print("zoom", zoom)
 
             xx = 0


### PR DESCRIPTION
- Fixed scaling not being handled properly for cropped assets in thumbnails
- Fixed Qualification text not being processed properly when building the default match/phase options
- Fixed (L), (W) being displayed in the default match/phase options
- Average size is now taken from the asset pack configuration
- Delete the thumbnail data after posting it to Bluesky