### PR TITLE
Added compatibility for variants

### DIFF
--- a/src/Helpers/TSHAltTextHelper.py
+++ b/src/Helpers/TSHAltTextHelper.py
@@ -83,6 +83,7 @@ def generate_youtube(scoreboard_id=1, use_phase_name=True, use_characters=True):
         team_name = current_team_data.get("teamName")
         player_names = []
         player_names_with_characters = []
+        player_names_with_variants = []
         if team_name:
             title_long = f'{title_long}' + team_name
             title_short = f'{title_short}' + team_name
@@ -91,28 +92,38 @@ def generate_youtube(scoreboard_id=1, use_phase_name=True, use_characters=True):
             player_data = current_team_data.get("player")
             for player_id in player_data.keys():
                 character_names = []
+                character_names_with_variants = []
                 current_player_data = player_data.get(player_id)
                 player_name = current_player_data.get("mergedName")
                 character_data = current_player_data.get("character")
                 for character_id in character_data.keys():
                     current_character_data = character_data.get(character_id)
                     if current_character_data.get("name"):
-                        character_names.append(current_character_data.get("name"))
+                        current_character_name = current_character_data.get("name")
+                        current_character_name_with_variants = current_character_data.get("name")
+                        if current_character_data.get("variant", {}).get("name"):
+                            current_character_name_with_variants = f'{current_character_name} - {current_character_data.get("variant", {}).get("name")}'
+                        character_names.append(current_character_name)
+                        character_names_with_variants.append(current_character_name_with_variants)
                 if player_name:
                     if player_name.replace(' [L]', ''):
                         player_names.append(player_name.replace(" [L]", ""))
                         if character_names:
                             player_names_with_characters.append(
                                 f"{player_name.replace(' [L]', '')} ({', '.join(character_names)})")
+                            player_names_with_variants.append(
+                                f"{player_name.replace(' [L]', '')} ({', '.join(character_names_with_variants)})")
                         else:
                             player_names_with_characters.append(
+                                player_name.replace(" [L]", ""))
+                            player_names_with_variants.append(
                                 player_name.replace(" [L]", ""))
             title_long = f'{title_long}' + \
                 " / ".join(player_names_with_characters)
             title_short = f'{title_short}' + " / ".join(player_names)
             if use_characters:
                 description = description + \
-                    " / ".join(player_names_with_characters)
+                    " / ".join(player_names_with_variants)
             else:
                 description = description + \
                     " / ".join(player_names)
@@ -199,9 +210,11 @@ def generate_top_n_alt_text(bracket_type="DOUBLE_ELIMINATION"):
         current_team_data = team_list.get(team_id)
         team_name = current_team_data.get("teamName")
         players_text = []
+        players_text_with_variants = []
         player_data = current_team_data.get("player")
         for player_id in player_data.keys():
             character_names = []
+            character_names_with_variants = []
             current_player_data = player_data.get(player_id)
             player_name = current_player_data.get("mergedName")
             character_data = current_player_data.get("character")
@@ -212,25 +225,36 @@ def generate_top_n_alt_text(bracket_type="DOUBLE_ELIMINATION"):
             for character_id in character_data.keys():
                 current_character_data = character_data.get(character_id)
                 if current_character_data.get("name"):
-                    character_names.append(current_character_data.get("name"))
+                    current_character_name = current_character_data.get("name")
+                    current_character_name_with_variants = current_character_data.get("name")
+                    if current_character_data.get("variant", {}).get("name"):
+                        current_character_name_with_variants = f'{current_character_name} - {current_character_data.get("variant", {}).get("name")}'
+                    character_names.append(current_character_name)
+                    character_names_with_variants.append(current_character_name_with_variants)
             player_text = f"{player_name}"
             characters_text = ' / '.join(character_names)
+            characters_text_with_variants = ' / '.join(character_names_with_variants)
             if country_code:
                 if characters_text:
                     characters_text = country_code + ", " + characters_text
+                    characters_text_with_variants = country_code + ", " + characters_text_with_variants
                 else:
                     characters_text = country_code
+                    characters_text_with_variants = country_code
             if characters_text:
                 player_text = player_text + f" ({characters_text})"
+                player_text_with_variants = player_text + f" ({characters_text_with_variants})"
             if player_name:
                 players_text.append(player_text)
+                players_text_with_variants.append(player_text_with_variants)
         placement = CalculatePlacement(int(team_id), bracket_type)
         players_text = " / ".join(players_text)
+        player_text_with_variants = " / ".join(player_text_with_variants)
         if team_name:
             alt_text = alt_text + \
-                f"{placement}/ {team_name} [{players_text}]\n"
+                f"{placement}/ {team_name} [{player_text_with_variants}]\n"
         else:
-            alt_text = alt_text + f"{placement}/ {players_text}\n"
+            alt_text = alt_text + f"{placement}/ {player_text_with_variants}\n"
 
     alt_text = f"{alt_text}\n\n"
     commentator_data = data.get("commentary")

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -359,7 +359,7 @@ class TSHGameAssetManager(QObject):
                         biggestAverage = 0
 
                         for asset in list(gameObj.get("assets", {}).keys()):
-                            if gameObj["assets"][asset].get("complete") and gameObj["assets"][asset].get("average_size"):
+                            if gameObj["assets"][asset].get("complete") and gameObj["assets"][asset].get("average_size") and asset not in ["stage_icon", "variant_icon"]:
                                 size = sum(gameObj["assets"][asset].get(
                                     "average_size").values())
 

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -330,7 +330,7 @@ class TSHGameAssetManager(QObject):
 
                         # Set average size
                         for assetsKey in list(gameObj.get("assets", {}).keys()):
-                            if assetsKey != "base_files" and assetsKey != "stage_icon":
+                            if assetsKey != "base_files" and assetsKey not in ["stage_icon", "variant_icon"]:
                                 try:
                                     if len(widths.get(assetsKey, [])) > 0 and len(heights.get(assetsKey, [])) > 0:
                                         gameObj["assets"][assetsKey]["average_size"] = assetsObj.get("average_size")
@@ -855,10 +855,10 @@ class TSHGameAssetManager(QObject):
                 try:
                     # Skip stage icon asset packs
                     if type(asset.get("type")) == list:
-                        if "stage_icon" in asset.get("type"):
+                        if "stage_icon" in asset.get("type") or "variant_icon" in asset.get("type"):
                             continue
                     elif type(asset.get("type")) == str:
-                        if asset.get("type") == "stage_icon":
+                        if asset.get("type") in ["stage_icon", "variant_icon"]:
                             continue
 
                     assetPath = f'{self.selectedGame.get("path")}/{assetKey}/'

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -29,12 +29,14 @@ class TSHGameAssetManager(QObject):
         self.signals = TSHGameAssetManagerSignals()
         self.games = {}
         self.characters = {}
+        self.variants = {}
         self.selectedGame = {}
         self.stockIcons = {}
         self.startgg_id_to_character = {}
 
         self.characterModel = QStandardItemModel()
         self.skinModels = {}
+        self.variantModel = QStandardItemModel()
         self.stageModel = QStandardItemModel()
 
         StateManager.Set(f"game", {})
@@ -237,6 +239,7 @@ class TSHGameAssetManager(QObject):
 
                     if gameObj != None:
                         self.parent().characters = gameObj.get("character_to_codename", {})
+                        self.parent().variants = gameObj.get("variant_to_codename", {})
 
                         assetsKey = ""
                         if len(list(gameObj.get("assets", {}).keys())) > 0:
@@ -432,6 +435,46 @@ class TSHGameAssetManager(QObject):
                         except:
                             logger.error(traceback.format_exc())
 
+                        
+                        # Load translations for variants
+                        try:
+                            for c in self.parent().variants.keys():
+                                display_name = c
+                                export_name = c
+                                en_name = c
+
+                                if self.parent().variants[c].get("locale"):
+                                    locale = TSHLocaleHelper.programLocale
+                                    if locale.replace("-", "_") in self.parent().variants[c]["locale"]:
+                                        display_name = self.parent().variants[
+                                            c]["locale"][locale.replace("-", "_")]
+                                    elif re.split("-|_", locale)[0] in self.parent().variants[c]["locale"]:
+                                        display_name = self.parent().variants[
+                                            c]["locale"][re.split("-|_", locale)[0]]
+                                    elif TSHLocaleHelper.GetRemaps(TSHLocaleHelper.programLocale) in self.parent().variants[c]["locale"]:
+                                        display_name = self.parent().variants[c]["locale"][TSHLocaleHelper.GetRemaps(
+                                            TSHLocaleHelper.programLocale)]
+
+                                    locale = TSHLocaleHelper.exportLocale
+                                    if locale.replace("-", "_") in self.parent().variants[c]["locale"]:
+                                        export_name = self.parent().variants[
+                                            c]["locale"][locale.replace("-", "_")]
+                                    elif re.split("-|_", locale)[0] in self.parent().variants[c]["locale"]:
+                                        export_name = self.parent().variants[
+                                            c]["locale"][re.split("-|_", locale)[0]]
+                                    elif TSHLocaleHelper.GetRemaps(TSHLocaleHelper.exportLocale) in self.parent().variants[c]["locale"]:
+                                        export_name = self.parent().variants[c]["locale"][TSHLocaleHelper.GetRemaps(
+                                            TSHLocaleHelper.exportLocale)]
+
+                                self.parent(
+                                ).variants[c]["display_name"] = display_name
+                                self.parent(
+                                ).variants[c]["export_name"] = export_name
+                                self.parent(
+                                ).variants[c]["en_name"] = en_name
+                        except:
+                            logger.error(traceback.format_exc())
+
                     StateManager.Set(f"game", {
                         "name": self.parent().selectedGame.get("name"),
                         "smashgg_id": self.parent().selectedGame.get("smashgg_game_id"),
@@ -441,6 +484,7 @@ class TSHGameAssetManager(QObject):
 
                     self.parent().UpdateCharacterModel()
                     self.parent().UpdateSkinModel()
+                    self.parent().UpdateVariantModel()
                     self.parent().UpdateStageModel()
                     self.parent().signals.onLoad.emit()
                 except:
@@ -601,6 +645,58 @@ class TSHGameAssetManager(QObject):
             self.characterModel.sort(0)
         except:
             logger.error(traceback.format_exc())
+
+    def UpdateVariantModel(self):
+        try:
+            self.variantModel = QStandardItemModel()
+
+            # Add one empty
+            item = QStandardItem("")
+            self.variantModel.appendRow(item)
+
+            for c in self.variants.keys():
+                item = QStandardItem()
+                item.setData(c, Qt.ItemDataRole.EditRole)
+                print(c)
+
+                data = {
+                    "name": self.variants[c].get("export_name"),
+                    "en_name": c,
+                    "display_name": self.variants[c].get("display_name"),
+                    "codename": self.variants[c].get("codename")
+                }
+
+                
+                data["icon_path"] = self.GetVariantIconPath(data["codename"])
+                if data["icon_path"]:
+                    item.setIcon(QIcon(QPixmap.fromImage(QImage(data["icon_path"])))
+                    )
+                else:
+                    item.setIcon(QIcon(QPixmap.fromImage(QImage('./assets/icons/cancel.svg')))
+                    )
+
+                if self.variants[c].get("display_name") != c:
+                    item.setData(
+                        f'{self.variants[c].get("display_name")} / {c}', Qt.ItemDataRole.EditRole)
+
+                item.setData(data, Qt.ItemDataRole.UserRole)
+                self.variantModel.appendRow(item)
+
+            self.variantModel.sort(0)
+        except:
+            logger.error(traceback.format_exc())
+
+    def GetVariantIconPath(self, variant_codename):
+        game_codename = self.selectedGame.get("codename")
+        icon_path, asset_root_path = "", "./user_data/games"
+        icon_config_path = f"{asset_root_path}/{game_codename}/variant_icon/config.json"
+        if os.path.isfile(icon_config_path):
+            with open(icon_config_path, "rt", encoding="utf-8") as icon_config_file:
+                icon_config = json.loads(icon_config_file.read())
+            icon_filename = f"{asset_root_path}/{game_codename}/variant_icon/{icon_config.get('prefix')}{variant_codename}{icon_config.get('postfix')}.png"
+            if os.path.isfile(icon_filename):
+                icon_path = icon_filename
+        return(icon_path)
 
     def UpdateSkinModel(self):
         self.skinModels = {}

--- a/src/TSHPlayerDB.py
+++ b/src/TSHPlayerDB.py
@@ -142,10 +142,12 @@ class TSHPlayerDB:
                                 if playerMains is not None and len(playerMains) > 0:
                                     # Must be a list of size 2 [character, skin]
                                     playerMains = [main for main in playerMains if isinstance(
-                                        main, list) and len(main) == 2]
+                                        main, list) and (len(main) == 2) or (len(main) == 3)]
 
                                     # If the skin is invalid, default to 0
                                     for main in playerMains:
+                                        while len(main) < 3:
+                                            main.append("")
                                         skin = 0
                                         try:
                                             skin = int(main[1])
@@ -154,6 +156,14 @@ class TSHPlayerDB:
                                                 f'Local DB error: Player {player.get("gamerTag")} has an invalid skin for character {main[0]}')
                                             logger.error(traceback.format_exc())
                                         main[1] = skin
+
+                                        # If no variant, set to none
+                                        if len(main) >=3:
+                                            variant = main[2]
+                                        else:
+                                            variant = ""
+                                        main[2] = variant
+                                        
 
                                     if playerMains[0][0] in TSHGameAssetManager.instance.characters.keys():
                                         character = playerMains[0]

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -398,16 +398,16 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             # Add variant
             player_variant = QComboBox()
             character_element.layout().addWidget(player_variant)
-            player_variant.setIconSize(QSize(48, 48))
+            player_variant.setIconSize(QSize(24, 24))
             player_variant.setFixedHeight(32)
-            player_variant.setMinimumWidth(64)
+            player_variant.setMinimumWidth(60)
             player_variant.setMaximumWidth(120)
             player_variant.setFont(
                 QFont(player_variant.font().family(), 9))
             player_variant.setModel(
                 TSHGameAssetManager.instance.variantModel)
             view = QListView()
-            view.setIconSize(QSize(24, 24))
+            view.setIconSize(QSize(48, 48))
             player_variant.setView(view)
 
             # Move up/down

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -176,7 +176,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         with self.dataLock:
             characters = {}
 
-            for i, (element, character, color) in enumerate(self.character_elements):
+            for i, (element, character, color, variant) in enumerate(self.character_elements):
                 data = character.currentData()
 
                 if data == None:
@@ -198,6 +198,10 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                     data["assets"] = {}
 
                 data["skin"] = color.currentIndex()
+                if variant.currentData():
+                    data["variant"] = variant.currentData()
+                else:
+                    data["variant"] = {}
 
                 characters[i+1] = data
 
@@ -391,6 +395,21 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             # self.player_character_color.activated.connect(self.CharacterChanged)
             # self.CharacterChanged()
 
+            # Add variant
+            player_variant = QComboBox()
+            character_element.layout().addWidget(player_variant)
+            player_variant.setIconSize(QSize(48, 48))
+            player_variant.setFixedHeight(32)
+            player_variant.setMinimumWidth(64)
+            player_variant.setMaximumWidth(120)
+            player_variant.setFont(
+                QFont(player_variant.font().family(), 9))
+            player_variant.setModel(
+                TSHGameAssetManager.instance.variantModel)
+            view = QListView()
+            view.setIconSize(QSize(128, 128))
+            player_variant.setView(view)
+
             # Move up/down
             btMoveUp = QPushButton()
             btMoveUp.setFixedSize(24, 24)
@@ -409,7 +428,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             self.character_container.layout().addWidget(character_element)
 
             self.character_elements.append(
-                [character_element, player_character, player_character_color])
+                [character_element, player_character, player_character_color, player_variant])
 
             player_character.currentIndexChanged.connect(
                 lambda x, element=player_character, target=player_character_color: [
@@ -423,14 +442,23 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                     self.CharactersChanged()
                 ]
             )
+            
+            player_variant.currentIndexChanged.connect(
+                lambda index, element=player_character: [
+                    self.CharactersChanged()
+                ]
+            )
 
             player_character.setCurrentIndex(0)
             player_character_color.setCurrentIndex(0)
+            player_variant.setCurrentIndex(0)
 
             player_character.setObjectName(
                 f"character_{len(self.character_elements)}")
             player_character_color.setObjectName(
                 f"character_color_{len(self.character_elements)}")
+            player_variant.setObjectName(
+                f"variant_{len(self.character_elements)}")
 
         while len(self.character_elements) > number:
             self.character_elements[-1][0].setParent(None)
@@ -565,6 +593,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             c[1].setModel(TSHGameAssetManager.instance.characterModel)
             c[1].setIconSize(QSize(24, 24))
             c[1].setFixedHeight(32)
+            c[3].setModel(TSHGameAssetManager.instance.variantModel)
 
     def SetupAutocomplete(self):
         if TSHPlayerDB.model:
@@ -702,6 +731,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                         if i < len(self.character_elements):
                             character_element = self.character_elements[i][1]
                             color_element = self.character_elements[i][2]
+                            variant_element = self.character_elements[i][3]
                             characterIndex = 0
                             for i in range(character_element.model().rowCount()):
                                 item = character_element.model().item(i).data(Qt.ItemDataRole.UserRole)
@@ -718,6 +748,23 @@ class TSHScoreboardPlayerWidget(QGroupBox):
                             else:
                                 if color_element.currentIndex() != 0:
                                     color_element.setCurrentIndex(0)
+                            
+                            variantIndex = 0
+                            if variant_element:
+                                for i in range(variant_element.model().rowCount()):
+                                    item = variant_element.model().item(i).data(Qt.ItemDataRole.UserRole)
+                                    if item:
+                                        if len(main) >= 3 :
+                                            if item.get("en_name") == main[2]:
+                                                variantIndex = i
+                                                break
+                                        else:
+                                            variantIndex = 0
+                                            break
+                            else:
+                                variantIndex = 0
+                            if variant_element.currentIndex() != variantIndex:
+                                variant_element.setCurrentIndex(variantIndex)
 
             if data.get("seed"):
                 StateManager.Set(f"{self.path}.seed", data.get("seed"))
@@ -744,7 +791,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         if TSHGameAssetManager.instance.selectedGame.get("codename"):
             mains = []
 
-            for i, (element, character, color) in enumerate(self.character_elements):
+            for i, (element, character, color, variant) in enumerate(self.character_elements):
                 data = {}
 
                 if character.currentData() is not None:
@@ -756,9 +803,14 @@ class TSHScoreboardPlayerWidget(QGroupBox):
 
                 if data["skin"] == None:
                     data["skin"] = 0
+                    
+                if variant.currentData():
+                    data["variant"] = variant.currentData().get("en_name", "")
+                else:
+                    data["variant"] = ""
 
                 if data["name"] != "":
-                    mains.append([data.get("name"), data.get("skin")])
+                    mains.append([data.get("name"), data.get("skin"), data.get("variant")])
 
             playerData["mains"] = {
                 TSHGameAssetManager.instance.selectedGame.get("codename"): mains

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -407,7 +407,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             player_variant.setModel(
                 TSHGameAssetManager.instance.variantModel)
             view = QListView()
-            view.setIconSize(QSize(48, 48))
+            view.setIconSize(QSize(24, 24))
             player_variant.setView(view)
 
             # Move up/down

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -407,7 +407,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
             player_variant.setModel(
                 TSHGameAssetManager.instance.variantModel)
             view = QListView()
-            view.setIconSize(QSize(128, 128))
+            view.setIconSize(QSize(24, 24))
             player_variant.setView(view)
 
             # Move up/down

--- a/src/TSHThumbnailSettingsWidget.py
+++ b/src/TSHThumbnailSettingsWidget.py
@@ -949,7 +949,7 @@ class TSHThumbnailSettingsWidget(QDockWidget):
                 if key == "base_files":
                     continue
                 # Skip stage icon assets
-                if isinstance(val.get("type"), list) and "stage_icon" in val.get("type"):
+                if isinstance(val.get("type"), list) and ("stage_icon" in val.get("type") or "variant_icon" in val.get("type")):
                     continue
                 if val.get("name"):
                     self.selectRenderType.addItem(val.get("name"), key)

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -1304,7 +1304,7 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1318,7 +1318,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation>Neuen Spieler speichern</translation>
     </message>
@@ -1333,7 +1333,7 @@ p, li { white-space: pre-wrap; }
         <translation>Zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation>Spielereintrag aktualisieren</translation>
     </message>

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -713,35 +713,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -708,35 +708,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -1132,7 +1132,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1147,7 +1147,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1155,7 +1155,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -718,35 +718,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -1319,7 +1319,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation>Guardar nuevo jugador</translation>
     </message>
@@ -1334,7 +1334,7 @@ p, li { white-space: pre-wrap; }
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1342,7 +1342,7 @@ p, li { white-space: pre-wrap; }
         <translation>Jugador {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation>Actualizar jugador</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -713,35 +713,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation>Jeu :</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation>contre</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation>Commentateurs :</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation>Stream produit avec Tournament Stream Helper :</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation>Résultats :</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation>Stream produit avec Tournament Stream Helper</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -1235,7 +1235,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation>Sauvegarder le joueur</translation>
     </message>
@@ -1250,7 +1250,7 @@ p, li { white-space: pre-wrap; }
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1258,7 +1258,7 @@ p, li { white-space: pre-wrap; }
         <translation>Joueur {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation>Mettre à jour le joueur</translation>
     </message>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -708,35 +708,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -1188,7 +1188,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1203,7 +1203,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1211,7 +1211,7 @@ p, li { white-space: pre-wrap; }
         <translation>Giocatore {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation>Aggionare il giocatore</translation>
     </message>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -721,35 +721,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -1207,7 +1207,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation>プレイヤーエントリーを保存</translation>
     </message>
@@ -1222,7 +1222,7 @@ p, li { white-space: pre-wrap; }
         <translation>リセット</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1230,7 +1230,7 @@ p, li { white-space: pre-wrap; }
         <translation>プレイヤー{0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation>プレイヤーエントリーを更新</translation>
     </message>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -1254,7 +1254,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation>Salvar novo jogador</translation>
     </message>
@@ -1269,7 +1269,7 @@ p, li { white-space: pre-wrap; }
         <translation>Limpar</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1277,7 +1277,7 @@ p, li { white-space: pre-wrap; }
         <translation>Jogador {0}</translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation>Atualizar jogador</translation>
     </message>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -720,35 +720,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation>Jogo:</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation>VS</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation>Comentaristas:</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation>Transmissão utilizando TournamentStreamHelper</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation>Colocações:</translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation>Transmissão utilizando TournamentStreamHelper</translation>
     </message>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -1188,7 +1188,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1203,7 +1203,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1211,7 +1211,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -708,35 +708,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -1188,7 +1188,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHScoreboardPlayerWidget.py" line="70"/>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="793"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="845"/>
         <source>Save new player</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1203,7 +1203,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="350"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="354"/>
         <location filename="../TSHSelectSetWindow.py" line="115"/>
         <location filename="../TSHSelectSetWindow.py" line="117"/>
         <location filename="../thumbnail/main_generate_thumbnail.py" line="1183"/>
@@ -1211,7 +1211,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHScoreboardPlayerWidget.py" line="790"/>
+        <location filename="../TSHScoreboardPlayerWidget.py" line="842"/>
         <source>Update player</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -708,35 +708,35 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../Helpers/TSHAltTextHelper.py" line="65"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="189"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="200"/>
         <source>Game:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="122"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="124"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="126"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="133"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="135"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="137"/>
         <source>VS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="138"/>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="245"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="149"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="269"/>
         <source>Commentators:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="141"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="152"/>
         <source>Stream powered by TournamentStreamHelper:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="190"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="201"/>
         <source>Standings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Helpers/TSHAltTextHelper.py" line="251"/>
+        <location filename="../Helpers/TSHAltTextHelper.py" line="275"/>
         <source>Stream powered by TournamentStreamHelper</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
- Added compatibility for variants
  - A variant is defined as an element which can affect the player’s character or playstyle without being another full character or being specific to a certain character. These can include:
    - Assist-only characters (e.g. Mortal Kombat 1, Idol Showdown, Fraymakers)
    - "Groove" systems (e.g. Capcom VS SNK 2 grooves, Street Fighter 6 Classic/Modern controls, Street Fighter Alpha 3 -ISM system, KOF98UMFE Power modes, Street Fighter V V-Trigger & V-Skill combinations)
  - Variants must be defined in the main `config.json` of the game
  - Variant icons (for now) go into the `variant_icon` pack. Please note that only PNGs are supported
    - PR for control styles in Street Fighter 6: https://github.com/joaorb64/StreamHelperAssets/pull/650
  - Only one variant type is supported per game

![image](https://github.com/user-attachments/assets/f4374786-ef9c-4a86-a1e5-a95f54100da4)
