### PR TITLE
Change commentators data through the HTTP server

### DIFF
--- a/assets/contributors.txt
+++ b/assets/contributors.txt
@@ -6,8 +6,8 @@ TwilCynder
 ladyisatis
 Kekwel
 sticks-stuff
-ashleygruver
 Justin Takamiya
+ashleygruver
 Gullgum
 Lunki51
 cash12121
@@ -16,6 +16,7 @@ Imeryl
 Eric Iniguez
 ImranVirani
 Nillan-E
+skpeter
 TNTBlowzUp
 IcyKeswick
 CrazyLi825

--- a/src/TSHCommentaryWidget.py
+++ b/src/TSHCommentaryWidget.py
@@ -14,6 +14,7 @@ from .TSHGameAssetManager import TSHGameAssetManager
 
 class TSHCommentaryWidget(QDockWidget):
     ChangeCommDataSignal = Signal(int, object)
+    LoadCommFromTagSignal = Signal(int, str, bool)
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -34,6 +35,7 @@ class TSHCommentaryWidget(QDockWidget):
         self.widget.layout().addWidget(topOptions)
         
         self.ChangeCommDataSignal.connect(self.SetData)
+        self.LoadCommFromTagSignal.connect(self.LoadCommentatorFromTag)
 
         col = QWidget()
         col.setLayout(QVBoxLayout())
@@ -101,7 +103,7 @@ class TSHCommentaryWidget(QDockWidget):
 
         self.widget.layout().addWidget(scrollArea)
 
-        self.commentaryWidgets = []
+        self.commentaryWidgets: list[TSHScoreboardPlayerWidget] = []
 
         StateManager.Set("commentary", {})
         self.commentatorNumber.setValue(2)
@@ -122,6 +124,17 @@ class TSHCommentaryWidget(QDockWidget):
         logger.info(commentatorWidget)
         commentatorWidget.SetData(data, False, False)
 
+    def LoadCommentatorFromTag(self, index: int, tag: str, no_mains: bool):
+        if index > len(self.commentaryWidgets) - 1:
+            self.SetCommentatorNumber(index+1)
+            self.commentatorNumber.setValue(index+1)
+
+        playerData = TSHPlayerDB.GetPlayerFromTag(tag)
+        if playerData:
+            widget = self.commentaryWidgets[index]
+            widget.SetData(playerData, False, True, no_mains)
+            return True
+        return False
 
     def SetCommentatorNumber(self, number):
         while len(self.commentaryWidgets) < number:

--- a/src/TSHCommentaryWidget.py
+++ b/src/TSHCommentaryWidget.py
@@ -13,6 +13,8 @@ from .TSHGameAssetManager import TSHGameAssetManager
 
 
 class TSHCommentaryWidget(QDockWidget):
+    ChangeCommDataSignal = Signal(int, object)
+
     def __init__(self, *args):
         super().__init__(*args)
         self.setWindowTitle(QApplication.translate("app", "Commentary"))
@@ -30,6 +32,8 @@ class TSHCommentaryWidget(QDockWidget):
         topOptions.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Maximum)
 
         self.widget.layout().addWidget(topOptions)
+        
+        self.ChangeCommDataSignal.connect(self.SetData)
 
         col = QWidget()
         col.setLayout(QVBoxLayout())
@@ -106,6 +110,17 @@ class TSHCommentaryWidget(QDockWidget):
         TSHGameAssetManager.instance.signals.onLoad.connect(
             self.SetDefaultsFromAssets
         )
+
+    def SetData(self, index, data):
+        if index > len(self.commentaryWidgets):
+            self.SetCommentatorNumber(index+1)
+            self.commentatorNumber.setValue(index+1)
+
+        logger.info(index)
+
+        commentatorWidget = self.commentaryWidgets[index]
+        logger.info(commentatorWidget)
+        commentatorWidget.SetData(data, False, False)
 
 
     def SetCommentatorNumber(self, number):

--- a/src/TSHPlayerDB.py
+++ b/src/TSHPlayerDB.py
@@ -123,6 +123,12 @@ class TSHPlayerDB:
         TSHPlayerDB.SaveDB()
         TSHPlayerDB.SetupModel()
 
+    def GetPlayerFromTag(tag):
+        for player_db in TSHPlayerDB.database.values():
+            if tag.lower() == player_db.get("gamerTag").lower():
+                return player_db
+        return None
+
     def SetupModel():
         with TSHPlayerDB.modelLock:
             TSHPlayerDB.model = QStandardItemModel()

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -1142,13 +1142,13 @@ class TSHScoreboardWidget(QWidget):
 
         if self.teamsSwapped:
             teamInstances.reverse()
-        for player_db in TSHPlayerDB.database.values():
-            if tag.lower() == player_db.get("gamerTag").lower():
-                teamInstances[team][player].SetData(
-                    player_db, False, True, no_mains)
-                return True
-        else:
-            return False
+
+        playerData = TSHPlayerDB.GetPlayerFromTag(tag)
+        if playerData:
+            teamInstances[team][player].SetData(
+                    playerData, False, True, no_mains)
+            return True
+        return False
 
     def SetDefaultsFromAssets(self):
         if StateManager.Get(f'game.defaults'):

--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -478,6 +478,23 @@ class WebServer(QThread):
         emit('load_player_from_tag', WebServer.actions.load_player_from_tag(
             scoreboardNumber, html.unescape(args.get('tag')), team, player, no_mains))
 
+    @app.route('/load-commentator-from-tag-<caster>')
+    def load_commentator_from_tag(caster):
+        if request.args.get('tag') is None:
+            return "No tag provided"
+        no_mains = request.args.get('no-mains') is not None
+        return WebServer.actions.load_commentator_from_tag(caster, html.unescape(request.args.get('tag')), no_mains)
+
+    @socketio.on('load_commentator_from_tag')
+    def ws_load_commentator_from_tag(message):
+        args = orjson.loads(message)
+        if args.get('tag') is None:
+            emit('load_commentator_from_tag', 'No tag provided')
+            return
+        no_mains = args.get('no-mains') is not None
+        caster = args.get('commentator')
+        emit('load_commentator_from_tag', WebServer.actions.load_commentator_from_tag(caster, html.unescape(args.get('tag')), no_mains))
+
     # Update bracket
     @app.route('/set-tournament')
     def set_tournament():

--- a/src/TSHWebServerActions.py
+++ b/src/TSHWebServerActions.py
@@ -12,6 +12,7 @@ from .TSHGameAssetManager import TSHGameAssetManager
 from .TSHBracketView import TSHBracketView
 from .TSHBracketWidget import TSHBracketWidget
 from .TSHTournamentDataProvider import TSHTournamentDataProvider
+from .TSHCommentaryWidget import TSHCommentaryWidget
 from .Workers import Worker
 
 import logging
@@ -20,10 +21,11 @@ log.setLevel(logging.ERROR)
 
 
 class WebServerActions(QThread):
-    def __init__(self, parent=None, scoreboard=None, stageWidget=None) -> None:
+    def __init__(self, parent=None, scoreboard=None, stageWidget=None, commentaryWidget: TSHCommentaryWidget=None) -> None:
         super().__init__(parent)
         self.scoreboard = scoreboard
         self.stageWidget = stageWidget
+        self.commentaryWidget = commentaryWidget
         self.threadPool = QThreadPool()
 
     def program_state(self):
@@ -220,6 +222,15 @@ class WebServerActions(QThread):
             "player": player,
             "data": data
         })
+        return "OK"
+
+    def set_commentary_data(self, index, data):
+        logger.info(self.commentaryWidget)
+        index = int(index) - 1
+        if index < 0:
+            return "ERROR : index can't be lower than 1"
+        self.commentaryWidget.ChangeCommDataSignal.emit(index, data)
+
         return "OK"
 
     def get_characters(self):

--- a/src/TSHWebServerActions.py
+++ b/src/TSHWebServerActions.py
@@ -391,6 +391,12 @@ class WebServerActions(QThread):
         else:
             return "ERROR"
 
+    def load_commentator_from_tag(self, index, tag, no_mains=False):
+        index = int(index) - 1
+        if index < 0:
+            return "ERROR : index can't be lower than 1" 
+        result = self.commentaryWidget.LoadCommFromTagSignal.emit(index, tag, no_mains)
+
     def load_tournament(self, url=None):
         logger.error(f"URL PROVIDED: {url}")
         if url is None or  url == "":

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -359,16 +359,16 @@ class Window(QMainWindow):
             Qt.DockWidgetArea.BottomDockWidgetArea, self.stageWidget)
         self.dockWidgets.append(self.stageWidget)
 
-        self.webserver = WebServer(
-            parent=None, stageWidget=self.stageWidget)
-        StateManager.webServer = self.webserver
-        self.webserver.start()
-
         commentary = TSHCommentaryWidget()
         commentary.setWindowIcon(QIcon('assets/icons/mic.svg'))
         commentary.setObjectName(QApplication.translate("app", "Commentary"))
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, commentary)
         self.dockWidgets.append(commentary)
+
+        self.webserver = WebServer(
+            parent=None, stageWidget=self.stageWidget, commentaryWidget=commentary)
+        StateManager.webServer = self.webserver
+        self.webserver.start()
 
         playerList = TSHPlayerListWidget()
         playerList.setWindowIcon(QIcon('assets/icons/list.svg'))

--- a/src/i18n/TSH_de.ts
+++ b/src/i18n/TSH_de.ts
@@ -768,7 +768,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
@@ -864,8 +864,8 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation>Kommentar</translation>
     </message>
@@ -1369,31 +1369,31 @@ p, li { white-space: pre-wrap; }
         <translation>Thumbnail erstellen</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation>Klarname</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation>Twitter</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation>Staat/Region</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>Charaktere</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation>Pronomen</translation>
@@ -1466,7 +1466,7 @@ p, li { white-space: pre-wrap; }
         <translation>User-Set laden</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation>Zahl der Kommentatoren</translation>
     </message>

--- a/src/i18n/TSH_en.ts
+++ b/src/i18n/TSH_en.ts
@@ -763,7 +763,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
@@ -875,8 +875,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1182,31 +1182,31 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>
@@ -1264,7 +1264,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/TSH_es.ts
+++ b/src/i18n/TSH_es.ts
@@ -773,7 +773,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
@@ -869,8 +869,8 @@ p, li { white-space: pre-wrap; }
         <translation>Marcador</translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation>Comentario</translation>
     </message>
@@ -1378,31 +1378,31 @@ p, li { white-space: pre-wrap; }
         <translation>Generar Miniatura</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation>Nombre Real</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation>Localidad</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>Personajes</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation>Pronombres</translation>
@@ -1475,7 +1475,7 @@ p, li { white-space: pre-wrap; }
         <translation>Cargar set de usuario</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation>Número de comentaristas</translation>
     </message>

--- a/src/i18n/TSH_fr.ts
+++ b/src/i18n/TSH_fr.ts
@@ -771,8 +771,8 @@ p, li { white-space: pre-wrap; }
         <translation>Tableau des scores</translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation>Commentateurs</translation>
     </message>
@@ -1191,7 +1191,7 @@ p, li { white-space: pre-wrap; }
         <translation>Téléchargement de {0}...</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation>Nombre de commentateurs</translation>
     </message>
@@ -1213,7 +1213,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
@@ -1508,31 +1508,31 @@ p, li { white-space: pre-wrap; }
         <translation>Équipe {0}</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation>Nom Réel</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation>Twitter</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation>Lieu</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>Personnages</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation>Pronoms</translation>

--- a/src/i18n/TSH_it.ts
+++ b/src/i18n/TSH_it.ts
@@ -793,8 +793,8 @@ p, li { white-space: pre-wrap; }
         <translation>Scenario</translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation>Commentatori</translation>
     </message>
@@ -1161,14 +1161,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
         <translation>Personaggi per giocatore</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1268,31 +1268,31 @@ p, li { white-space: pre-wrap; }
         <translation>Generare la miniatura</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation type="unfinished">Nome legale</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>Personaggi</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>

--- a/src/i18n/TSH_ja.ts
+++ b/src/i18n/TSH_ja.ts
@@ -780,8 +780,8 @@ p, li { white-space: pre-wrap; }
         <translation>スコアボード</translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation>解説</translation>
     </message>
@@ -1163,7 +1163,7 @@ p, li { white-space: pre-wrap; }
         <translation>{0}をダウンロード中...</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation>解説者の数</translation>
     </message>
@@ -1185,7 +1185,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
@@ -1396,31 +1396,31 @@ p, li { white-space: pre-wrap; }
         <translation>各チームのプレイヤー数</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation>本名</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation>ツイッター</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation>本拠地</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>使用キャラクター</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation>代名詞</translation>

--- a/src/i18n/TSH_pt-BR.ts
+++ b/src/i18n/TSH_pt-BR.ts
@@ -784,8 +784,8 @@ p, li { white-space: pre-wrap; }
         <translation>Placar</translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation>Comentário</translation>
     </message>
@@ -1210,7 +1210,7 @@ p, li { white-space: pre-wrap; }
         <translation>Baixando {0}...</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation>Número de comentaristas</translation>
     </message>
@@ -1232,7 +1232,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
@@ -1455,31 +1455,31 @@ p, li { white-space: pre-wrap; }
         <translation>Gerar Thumbnail</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation>Nome Real</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation>Local</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>Personagens</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation>Pronomes</translation>

--- a/src/i18n/TSH_zh-CN.ts
+++ b/src/i18n/TSH_zh-CN.ts
@@ -793,8 +793,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,14 +1161,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1268,31 +1268,31 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>角色</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>

--- a/src/i18n/TSH_zh-TW.ts
+++ b/src/i18n/TSH_zh-TW.ts
@@ -793,8 +793,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TournamentStreamHelper.py" line="369"/>
-        <location filename="../TSHCommentaryWidget.py" line="18"/>
+        <location filename="../TournamentStreamHelper.py" line="364"/>
+        <location filename="../TSHCommentaryWidget.py" line="21"/>
         <source>Commentary</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,14 +1161,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../TSHBracketWidget.py" line="93"/>
-        <location filename="../TSHCommentaryWidget.py" line="48"/>
+        <location filename="../TSHCommentaryWidget.py" line="54"/>
         <location filename="../TSHPlayerListWidget.py" line="75"/>
         <location filename="../TSHScoreboardWidget.py" line="167"/>
         <source>Characters per player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="40"/>
+        <location filename="../TSHCommentaryWidget.py" line="46"/>
         <source>Number of commentators</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1268,31 +1268,31 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="73"/>
+        <location filename="../TSHCommentaryWidget.py" line="79"/>
         <location filename="../TSHScoreboardWidget.py" line="229"/>
         <source>Real Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="74"/>
+        <location filename="../TSHCommentaryWidget.py" line="80"/>
         <location filename="../TSHScoreboardWidget.py" line="230"/>
         <source>Twitter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="75"/>
+        <location filename="../TSHCommentaryWidget.py" line="81"/>
         <location filename="../TSHScoreboardWidget.py" line="231"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="76"/>
+        <location filename="../TSHCommentaryWidget.py" line="82"/>
         <location filename="../TSHScoreboardWidget.py" line="232"/>
         <source>Characters</source>
         <translation>角色</translation>
     </message>
     <message>
-        <location filename="../TSHCommentaryWidget.py" line="77"/>
+        <location filename="../TSHCommentaryWidget.py" line="83"/>
         <location filename="../TSHScoreboardWidget.py" line="233"/>
         <source>Pronouns</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Added two routes to the HTTP Server : 
- `/update-commentary-<caster>` (POST) : sets commentator data (passed as JSON body)
- `load-commentator-from-tag-<index>` : loads a commentator from their tag (passed as a request argument) using the same process as `scoreboard<scoreboardNumber>-load-player-from-tag-<team>-<player>`