### PR TITLE
FEATURE - Completed Sets and Other QoL Features

### DIFF
--- a/src/Helpers/TSHControllerHelper.py
+++ b/src/Helpers/TSHControllerHelper.py
@@ -76,20 +76,20 @@ class TSHControllerHelper(QObject):
             if os.path.exists(f"{controller_directory}/config.json"):
                 split = controller_directory.split("/")
                 controller_id = f"{split[-4]}/{split[-3]}/{split[-2]}"
-                print(f"Loading: {controller_id}")
+                # print(f"Loading: {controller_id}")
                 with open(f"{controller_directory}/config.json", "rt", encoding="utf-8") as config_file:
                     config_json = json.loads(config_file.read())
-                    if os.path.exists(f"{"/".join(split[:-2])}/config.json"):
-                        with open(f"{"/".join(split[:-2])}/config.json", "rt", encoding="utf-8") as manufacturer_file:
+                    if os.path.exists(f'{"/".join(split[:-2])}/config.json'):
+                        with open(f'{"/".join(split[:-2])}/config.json', "rt", encoding="utf-8") as manufacturer_file:
                             manufacturer = json.loads(manufacturer_file.read()).get("name")
-                            print(f"Manufacturer: {manufacturer}")
+                            # print(f"Manufacturer: {manufacturer}")
                     else:
                         manufacturer = None
 
-                    if os.path.exists(f"{"/".join(split[:-3])}/config.json"):
-                        with open(f"{"/".join(split[:-3])}/config.json", "rt", encoding="utf-8") as controller_type_file:
+                    if os.path.exists(f'{"/".join(split[:-3])}/config.json'):
+                        with open(f'{"/".join(split[:-3])}/config.json', "rt", encoding="utf-8") as controller_type_file:
                             controller_type = json.loads(controller_type_file.read()).get("name")
-                            print(f"Type: {controller_type}")
+                            # print(f"Type: {controller_type}")
                     else:
                         controller_type = None
 

--- a/src/Settings/TSHSettingsWindow.py
+++ b/src/Settings/TSHSettingsWindow.py
@@ -78,6 +78,14 @@ class TSHSettingsWindow(QDialog):
             False
         ))
 
+        generalSettings.append((
+            QApplication.translate(
+                "settings.hide_track_player", "Hide the StartGG player tracking functionality from TSH (takes effect on next restart)"),
+            "hide_track_player",
+            "checkbox",
+            False
+        ))
+
         self.add_setting_widget(QApplication.translate(
             "settings", "General"), SettingsWidget("general", generalSettings))
 
@@ -113,6 +121,68 @@ class TSHSettingsWindow(QDialog):
         self.add_setting_widget(QApplication.translate(
             "settings", "Hotkeys"), SettingsWidget("hotkeys", hotkeySettings))
             
+        # Add Display Options settings
+        displaySettings = []
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_name", "Show Real Name"),
+            "show_name",
+            "checkbox",
+            True
+        ))
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_social", "Show Social Media"),
+            "show_social",
+            "checkbox",
+            True
+        ))
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_location", "Show Location"),
+            "show_location",
+            "checkbox",
+            True
+        ))
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_characters", "Show Characters"),
+            "show_characters",
+            "checkbox",
+            True
+        ))
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_pronouns", "Show Pronouns"),
+            "show_pronouns",
+            "checkbox",
+            True
+        ))
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_controller", "Show Controller"),
+            "show_controller",
+            "checkbox",
+            True
+        ))
+
+        displaySettings.append((
+            QApplication.translate(
+                "settings.show_additional", "Show Additional Info"),
+            "show_additional",
+            "checkbox",
+            True
+        ))
+        
+        self.add_setting_widget(QApplication.translate(
+            "settings", "Default Display Options"), SettingsWidget("display_options", displaySettings))
+
         # Add Bluesky settings
         bskySettings = []
         bskySettings.append((

--- a/src/TSHCommentaryWidget.py
+++ b/src/TSHCommentaryWidget.py
@@ -8,6 +8,7 @@ from loguru import logger
 from .TSHScoreboardPlayerWidget import TSHScoreboardPlayerWidget
 from .Helpers.TSHBadWordFilter import TSHBadWordFilter
 from .TSHPlayerDB import TSHPlayerDB
+from .SettingsManager import SettingsManager
 from .StateManager import StateManager
 from .TSHGameAssetManager import TSHGameAssetManager
 
@@ -69,21 +70,25 @@ class TSHCommentaryWidget(QDockWidget):
         menu.addSection("Players")
 
         self.elements = [
-            ["Real Name", ["real_name", "real_nameLabel"]],
-            ["Twitter", ["twitter", "twitterLabel"]],
-            ["Location", ["locationLabel", "state", "country"]],
-            ["Characters", ["characters"]],
-            ["Pronouns", ["pronoun", "pronounLabel"]],
+            ["Real Name",              ["real_name", "real_nameLabel"],       "show_name"],
+            ["Twitter",                ["twitter", "twitterLabel"],           "show_social"],
+            ["Location",               ["locationLabel", "state", "country"], "show_location"],
+            ["Characters",             ["characters"],                        "show_characters"],
+            ["Pronouns",               ["pronoun", "pronounLabel"],           "show_pronouns"],
+            ["Controller",             ["controller", "controllerLabel"],     "show_controller"],
+            ["Additional information", ["custom_textbox"],                    "show_additional"],
         ]
         self.elements[0][0] = QApplication.translate("app", "Real Name")
         self.elements[1][0] = QApplication.translate("app", "Twitter")
         self.elements[2][0] = QApplication.translate("app", "Location")
         self.elements[3][0] = QApplication.translate("app", "Characters")
         self.elements[4][0] = QApplication.translate("app", "Pronouns")
+        self.elements[5][0] = QApplication.translate("app", "Controller")
+        self.elements[6][0] = QApplication.translate("app", "Additional information")
         for element in self.elements:
             action: QAction = self.eyeBt.menu().addAction(element[0])
             action.setCheckable(True)
-            action.setChecked(True)
+            action.setChecked(SettingsManager.Get(f"display_options.{element[2]}", True))
             action.toggled.connect(
                 lambda toggled, action=action, element=element: self.ToggleElements(action, element[1]))
         
@@ -112,6 +117,10 @@ class TSHCommentaryWidget(QDockWidget):
         TSHGameAssetManager.instance.signals.onLoad.connect(
             self.SetDefaultsFromAssets
         )
+
+        for x, element in enumerate(self.elements, start=1):
+            action: QAction = self.eyeBt.menu().actions()[x]
+            self.ToggleElements(action, element[1])
 
     def SetData(self, index, data):
         if index > len(self.commentaryWidgets):

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -218,13 +218,13 @@ class TSHScoreboardWidget(QWidget):
         menu.addSection("Players")
 
         self.elements = [
-            ["Real Name", ["real_name", "real_nameLabel"]],
-            ["Twitter", ["twitter", "twitterLabel"]],
-            ["Location", ["locationLabel", "state", "country"]],
-            ["Characters", ["characters"]],
-            ["Pronouns", ["pronoun", "pronounLabel"]],
-            ["Controller", ["controller", "controllerLabel"]],
-            ["Additional information", ["custom_textbox"]],
+            ["Real Name",              ["real_name", "real_nameLabel"],       "show_name"],
+            ["Twitter",                ["twitter", "twitterLabel"],           "show_social"],
+            ["Location",               ["locationLabel", "state", "country"], "show_location"],
+            ["Characters",             ["characters"],                        "show_characters"],
+            ["Pronouns",               ["pronoun", "pronounLabel"],           "show_pronouns"],
+            ["Controller",             ["controller", "controllerLabel"],     "show_controller"],
+            ["Additional information", ["custom_textbox"],                    "show_additional"],
         ]
         self.elements[0][0] = QApplication.translate("app", "Real Name")
         self.elements[1][0] = QApplication.translate("app", "Twitter")
@@ -236,7 +236,7 @@ class TSHScoreboardWidget(QWidget):
         for element in self.elements:
             action: QAction = self.eyeBt.menu().addAction(element[0])
             action.setCheckable(True)
-            action.setChecked(True)
+            action.setChecked(SettingsManager.Get(f"display_options.{element[2]}", True))
             action.toggled.connect(
                 lambda toggled, action=action, element=element: self.ToggleElements(action, element[1]))
 
@@ -289,7 +289,7 @@ class TSHScoreboardWidget(QWidget):
         hbox = QHBoxLayout()
         bottomOptions.layout().addLayout(hbox)
 
-        if self.scoreboardNumber <= 1:
+        if self.scoreboardNumber <= 1 and not SettingsManager.Get("general.hide_track_player", False) :
             self.btLoadPlayerSet = QPushButton("Load player set")
             self.btLoadPlayerSet.setIcon(
                 QIcon("./assets/icons/person_search.svg"))

--- a/src/TournamentDataProvider/StartGGCompleteSetQuery.txt
+++ b/src/TournamentDataProvider/StartGGCompleteSetQuery.txt
@@ -1,181 +1,181 @@
 query EventMatchListQuery($eventSlug: String!, $page: Int = 1, $filters: SetFilters = {}) {
-  event(slug: $eventSlug) {
-    id
-    sets(page: $page, perPage: 50, sortType: MAGIC, filters: $filters) {
-      pageInfo {
-        page
-        total
-        perPage
-        totalPages
-        sortBy
-      }
-      nodes {
-        id
-        isReportable
-        identifier
-        fullRoundText
-        winnerId
-        startAt
-        createdAt
-        state
-        setLink
-        filledSlots
-        stationNumber
-        vodUrl
-        identifier
-        updatedAtMicro
-        userTasks(ctaMode: PAGE_LINK, allowFallbackTasks: true) {
-            id
-            type
-            title
-            description
-            cta
-            state
-            meta
-            priority
-            timer {
-            endAt
-            title
-            description
-            __typename
-            }
-            __typename
-        }
-        paginatedSlots(query: {page: 1, perPage: 3}, includeByes: true) {
-            pageInfo {
-            total
-            __typename
-            }
-            nodes {
-            id
-            slotIndex
-            seedId
-            prereqType
-            prereqPlacement
-            entrant {
-                id
-                name
-                networkIdDisplayName
-                participants {
-                    player {
-                        id
-                        prefix
-                        name
-                        sets(page: 1, perPage: 3, filters: {hideEmpty: true}){
-                            nodes {
-                                games {
-                                    selections {
-                                        entrant
-                                        selectionValue
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    user {
-                        id
-                        prefix
-                        name
-                        authorizations(types: [TWITTER]) {
-                            externalUsername
-                        }
-                    }
-                }
-                __typename
-            }
-            seed {
-                id
-                isBye
-                __typename
-            }
-            set {
-                id
-                event {
-                id
-                videogame {
-                    id
-                    name
-                    __typename
-                }
-                __typename
-                }
-                __typename
-            }
-            originSet {
-                id
-                identifier
-                __typename
-            }
-            originProgression {
-                id
-                originPlacement
-                originPhase {
-                id
-                name
-                groupCount
-                __typename
-                }
-                originPhaseGroup {
-                id
-                displayIdentifier
-                __typename
-                }
-                __typename
-            }
-            __typename
-            standing {
-                id
-                stats {
-                score {
-                    label
-                    value
-                    displayValue
-                    __typename
-                }
-                __typename
-                }
-                __typename
-            }
-            __typename
-            }
-            __typename
-        }
-        phaseGroup {
-            id
-            bracketType
-            displayIdentifier
-            phase {
-            id
-            name
-            __typename
-            }
-            __typename
-        }
-        stream {
-            id
-            streamName
-            streamSource
-            streamUrl(streamUrlType: PAGE)
-            enabled
-            isOnline
-            __typename
-        }
-        tournament {
-            id
-            timezone
-            __typename
-        }
-        event {
-            id
-            slug
-            isOnline
-            isSingleBracket
-            __typename
-        }
-        __typename
-      }
-      __typename
-    }
-    __typename
-  }
+	event(slug: $eventSlug) {
+		id
+		sets(page: $page, perPage: 50, sortType: MAGIC, filters: $filters) {
+			pageInfo {
+				page
+				total
+				perPage
+				totalPages
+				sortBy
+			}
+			nodes {
+				id
+				isReportable
+				identifier
+				fullRoundText
+				winnerId
+				startAt
+				createdAt
+				state
+				setLink
+				filledSlots
+				stationNumber
+				vodUrl
+				identifier
+				updatedAtMicro
+				userTasks(ctaMode: PAGE_LINK, allowFallbackTasks: true) {
+					id
+					type
+					title
+					description
+					cta
+					state
+					meta
+					priority
+					timer {
+						endAt
+						title
+						description
+						__typename
+					}
+					__typename
+				}
+				paginatedSlots(query: {page: 1, perPage: 3}, includeByes: true) {
+						pageInfo {
+							total
+							__typename
+						}
+						nodes {
+							id
+							slotIndex
+							seedId
+							prereqType
+							prereqPlacement
+							seed {
+								id
+								isBye
+								__typename
+							}
+							entrant {
+								id
+								name
+								networkIdDisplayName
+								participants {
+									player {
+										id
+										prefix
+										name
+										sets(page: 1, perPage: 3, filters: {hideEmpty: true}){
+											nodes {
+												games {
+													selections {
+														entrant
+														selectionValue
+													}
+												}
+											}
+										}
+									}
+									user {
+										id
+										prefix
+										name
+										authorizations(types: [TWITTER]) {
+											externalUsername
+										}
+									}
+								}
+								__typename
+							}
+							set {
+								id
+								event {
+									id
+									videogame {
+										id
+										name
+										__typename
+									}
+									__typename
+								}
+								__typename
+							}
+							originSet {
+								id
+								identifier
+								__typename
+							}
+							originProgression {
+								id
+								originPlacement
+								originPhase {
+									id
+									name
+									groupCount
+									__typename
+								}
+								originPhaseGroup {
+									id
+									displayIdentifier
+									__typename
+								}
+								__typename
+							}
+							__typename
+							standing {
+								id
+								stats {
+									score {
+										label
+										value
+										displayValue
+										__typename
+									}
+									__typename
+								}
+								__typename
+							}
+							__typename
+						}
+						__typename
+				}
+				phaseGroup {
+					id
+					bracketType
+					displayIdentifier
+					phase {
+						id
+						name
+						__typename
+					}
+					__typename
+				}
+				stream {
+					id
+					streamName
+					streamSource
+					streamUrl(streamUrlType: PAGE)
+					enabled
+					isOnline
+					__typename
+				}
+				tournament {
+					id
+					timezone
+					__typename
+				}
+				event {
+					id
+					slug
+					isOnline
+					isSingleBracket
+					__typename
+				}
+				__typename
+			}
+			__typename
+		}
+		__typename
+	}
 }

--- a/src/TournamentDataProvider/StartGGCompletedSetsQuery.txt
+++ b/src/TournamentDataProvider/StartGGCompletedSetsQuery.txt
@@ -1,14 +1,12 @@
-query PlayerLastSetsQuery($eventSlug: String!, $playerID: ID!) {
+query CompletedSetsQuery($eventSlug: String!) {
 	event(slug: $eventSlug) {
-		sets(page: 1, perPage: 10, sortType: RECENT, filters: {playerIds: [$playerID]}) {
+		sets(page: 1, perPage: 10, sortType: RECENT, filters: {state: 3}) {
 			nodes {
 				id
 				slots {
-					seed {
-						seedNum
-					}
 					entrant {
 						id
+						name
 						initialSeedNum
 						participants {
 							id

--- a/src/TournamentDataProvider/StartGGEntrantsQuery.txt
+++ b/src/TournamentDataProvider/StartGGEntrantsQuery.txt
@@ -1,64 +1,64 @@
 query EventEntrantsListQuery($eventSlug: String!, $videogameId: Int, $page: Int!) {
-  event(slug: $eventSlug) {
-    id
-    videogame {
-      id
-      name
-    }
-    entrants(query: {page: $page, perPage: 64}) {
-      pageInfo {
-        page
-        total
-        perPage
-        totalPages
-        sortBy
-      }
-      nodes {
-        id
-        name
-        initialSeedNum
-        participants {
-          player {
-            id
-            gamerTag
-            prefix
-            name
-            sets(page: 1, perPage: 1, filters: { hideEmpty: true, videogameId: $videogameId, videogameIds: [$videogameId] }) {
-              nodes {
-                games {
-                  selections {
-                    entrant {
-                      participants {
-                        player {
-                          id
-                        }
-                      }
-                    }
-                    selectionValue
-                  }
-                }
-              }
-            }
-          }
-          user {
-            id
-            prefix
-            name
-            genderPronoun
-            location {
-              country
-              state
-              city
-            }
-            authorizations(types: [TWITTER]) {
-              externalUsername
-            }
-            images(type: "profile") {
-              url
-            }
-          }
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		id
+		videogame {
+			id
+			name
+		}
+		entrants(query: {page: $page, perPage: 64}) {
+			pageInfo {
+				page
+				total
+				perPage
+				totalPages
+				sortBy
+			}
+			nodes {
+				id
+				name
+				initialSeedNum
+				participants {
+					player {
+						id
+						gamerTag
+						prefix
+						name
+						sets(page: 1, perPage: 1, filters: { hideEmpty: true, videogameId: $videogameId, videogameIds: [$videogameId] }) {
+							nodes {
+								games {
+									selections {
+										entrant {
+											participants {
+												player {
+													id
+												}
+											}
+										}
+										selectionValue
+									}
+								}
+							}
+						}
+					}
+					user {
+						id
+						prefix
+						name
+						genderPronoun
+						location {
+							country
+							state
+							city
+						}
+						authorizations(types: [TWITTER]) {
+							externalUsername
+						}
+						images(type: "profile") {
+							url
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGFilteredSetsQuery.txt
+++ b/src/TournamentDataProvider/StartGGFilteredSetsQuery.txt
@@ -1,95 +1,95 @@
 query EventMatchListQuery($eventSlug: String!, $page: Int = 1, $filters: SetFilters = {}) {
-  event(slug: $eventSlug) {
-    id
-    videogame {
-        id
-        name
-    }
-    sets(page: $page, perPage: 50, sortType: MAGIC, filters: $filters) {
-      pageInfo {
-        page
-        total
-        perPage
-        totalPages
-        sortBy
-      }
-      nodes {
-        id
-        identifier
-        fullRoundText
-        state
-        setLink
-        filledSlots
-        stationNumber
-        paginatedSlots(query: {page: 1, perPage: 16}, includeByes: true) {
-            nodes {
-                id
-                slotIndex
-                entrant {
-                    id
-                    name
-                    networkIdDisplayName
-                    participants {
-                        player {
-                            id
-                            gamerTag
-                            prefix
-                            name
-                            sets(page: 1, perPage: 1, filters: {hideEmpty: true}){
-                                nodes {
-                                    games {
-                                        selections {
-                                            entrant{
-                                                participants {
-                                                    player {
-                                                        id
-                                                    }
-                                                }
-                                            }
-                                            selectionValue
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        user {
-                            id
-                            prefix
-                            name
-                            location {
-                                country
-                                state
-                                city
-                            }
-                            authorizations(types: [TWITTER]) {
-                                externalUsername
-                            }
-                            images(type: \"profile\") {
-                                url
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        phaseGroup {
-            id
-            bracketType
-            displayIdentifier
-            phase {
-                id
-                name
-            }
-        }
-        stream {
-            id
-            streamName
-            streamSource
-            streamUrl(streamUrlType: PAGE)
-            enabled
-            isOnline
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		id
+		videogame {
+			id
+			name
+		}
+		sets(page: $page, perPage: 50, sortType: MAGIC, filters: $filters) {
+			pageInfo {
+				page
+				total
+				perPage
+				totalPages
+				sortBy
+			}
+			nodes {
+				id
+				identifier
+				fullRoundText
+				state
+				setLink
+				filledSlots
+				stationNumber
+				paginatedSlots(query: {page: 1, perPage: 16}, includeByes: true) {
+					nodes {
+						id
+						slotIndex
+						entrant {
+							id
+							name
+							networkIdDisplayName
+							participants {
+								player {
+									id
+									gamerTag
+									prefix
+									name
+									sets(page: 1, perPage: 1, filters: {hideEmpty: true}){
+										nodes {
+											games {
+												selections {
+													entrant{
+														participants {
+															player {
+																id
+															}
+														}
+													}
+													selectionValue
+												}
+											}
+										}
+									}
+								}
+								user {
+									id
+									prefix
+									name
+									location {
+										country
+										state
+										city
+									}
+									authorizations(types: [TWITTER]) {
+										externalUsername
+									}
+									images(type: \"profile\") {
+										url
+									}
+								}
+							}
+						}
+					}
+				}
+				phaseGroup {
+					id
+					bracketType
+					displayIdentifier
+					phase {
+							id
+							name
+					}
+				}
+				stream {
+					id
+					streamName
+					streamSource
+					streamUrl(streamUrlType: PAGE)
+					enabled
+					isOnline
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGFutureSetQuery.txt
+++ b/src/TournamentDataProvider/StartGGFutureSetQuery.txt
@@ -1,57 +1,57 @@
 query FutureSetQuery($id: ID!) {
-    set(id: $id){
-        id
-        identifier
-        fullRoundText
-        totalGames
-        state
-        station {
-            number
-        }
-        event {
-            slug
-        }
-        slots {
-            entrant {
-                id
-                name
-                seeds {
-                    seedNum
-                }
-                participants {
-                    id
-                    user {
-                        id
-                        slug
-                        name
-                        genderPronoun
-                        location {
-                            city
-                            country
-                            state
-                        }
-                        images(type: "profile") {
-                            url
-                        }
-                        authorizations(types: [TWITTER]) {
-                            type
-                            externalUsername
-                        }
-                    }
-                    player {
-                        id
-                        gamerTag
-                        prefix
-                    }
-                }
-            }
-        }
-        phaseGroup {
-            displayIdentifier
-            phase {
-                name
-                groupCount
-            }
-        }
-    }
+	set(id: $id){
+		id
+		identifier
+		fullRoundText
+		totalGames
+		state
+		station {
+			number
+		}
+		event {
+			slug
+		}
+		slots {
+			entrant {
+				id
+				name
+				seeds {
+					seedNum
+				}
+				participants {
+					id
+					user {
+						id
+						slug
+						name
+						genderPronoun
+						location {
+							city
+							country
+							state
+						}
+						images(type: "profile") {
+							url
+						}
+						authorizations(types: [TWITTER]) {
+							type
+							externalUsername
+						}
+					}
+					player {
+						id
+						gamerTag
+						prefix
+					}
+				}
+			}
+		}
+		phaseGroup {
+			displayIdentifier
+			phase {
+				name
+				groupCount
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGPlayerTournamentHistoryQuery.txt
+++ b/src/TournamentDataProvider/StartGGPlayerTournamentHistoryQuery.txt
@@ -1,20 +1,22 @@
 query TournamentHistoryDataQuery($playerID: ID!, $gameID: ID!) {
-  player(id: $playerID) {
-    recentStandings(videogameId: $gameID, limit: 10) {
-      placement
-      entrant {
-        event {
-          name
-          numEntrants
-          startAt
-          tournament {
-            name
-            images(type: "profile") {
-              url
-            }
-          }
-        }
-      }
-    }
-  }
+	player(id: $playerID) {
+		recentStandings(videogameId: $gameID, limit: 10) {
+			placement
+			entrant {
+				event {
+					name
+					numEntrants
+					startAt
+					tournament {
+						name
+						venueAddress
+						startAt
+						images(type: "profile") {
+							url
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGRecentSetsQuery.txt
+++ b/src/TournamentDataProvider/StartGGRecentSetsQuery.txt
@@ -1,40 +1,40 @@
 query RecentSetsQuery($pid1: ID!, $pid2: ID!, $uid1: ID!, $uid2: ID! $page: Int!, $videogameId: ID!) {
-    user(id: $uid1) {
-        events(query: {page: $page, perPage: 10, filter: {videogameId: [$videogameId]}}) {
-            nodes {
-                isOnline
-                name
-                tournament {
-                    name
-                }
-                startAt
-                sets(page: 1, perPage: 100, filters: {playerIds: [$pid1, $uid1, $pid2, $uid2], hideEmpty: true, showByes: false}, sortType: RECENT) {
-                    nodes {
-                        id
-                        slots {
-                            entrant {
-                                id
-                                participants {
-                                    id
-                                    player {
-                                        id
-                                    }
-                                }
-                            }
-                        }
-                        entrant1Score
-                        entrant2Score
-                        winnerId
-                        fullRoundText
-                        phaseGroup {
-                            displayIdentifier
-                            phase {
-                                name
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+	user(id: $uid1) {
+		events(query: {page: $page, perPage: 10, filter: {videogameId: [$videogameId]}}) {
+			nodes {
+				isOnline
+				name
+				tournament {
+					name
+				}
+				startAt
+				sets(page: 1, perPage: 100, filters: {playerIds: [$pid1, $uid1, $pid2, $uid2], hideEmpty: true, showByes: false}, sortType: RECENT) {
+					nodes {
+						id
+						slots {
+							entrant {
+								id
+								participants {
+									id
+									player {
+										id
+									}
+								}
+							}
+						}
+						entrant1Score
+						entrant2Score
+						winnerId
+						fullRoundText
+						phaseGroup {
+							displayIdentifier
+							phase {
+								name
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGSetQuery.txt
+++ b/src/TournamentDataProvider/StartGGSetQuery.txt
@@ -1,96 +1,96 @@
 query SetQuery($id: ID!) {
-    set(id: $id) {
-        id
-        event {
-            hasTasks
-            videogame {
-                id
-            }
-            isOnline
-        }
-        fullRoundText
-        round
-        state
-        totalGames
-        entrant1Score
-        entrant2Score
-        slots {
-            entrant {
-                id
-                name
-                initialSeedNum
-                participants {
-                    id
-                    user {
-                        id
-                        slug
-                        name
-                        genderPronoun
-                        authorizations(types: [TWITTER]) {
-                            type
-                            externalUsername
-                        }
-                        location {
-                            city
-                            country
-                            state
-                        }
-                        images(type: "profile") {
-                            url
-                        }
-                    }
-                    player {
-                        id
-                        gamerTag
-                        prefix
-                        sets(page: 1, perPage: 1) {
-                            nodes {
-                                games {
-                                    selections {
-                                        entrant {
-                                            participants {
-                                                player {
-                                                    id
-                                                }
-                                            }
-                                        }
-                                        selectionValue
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        games {
-            selections {
-                entrant {
-                    id
-                    participants {
-                        player {
-                            id
-                        }
-                    }
-                }
-                selectionValue
-            }
-            winnerId
-        }
-        phaseGroup {
-            phase {
-                name
-                groupCount
-                bracketType
-                progressionsOut {
-                    id
-                }
-            }
-            displayIdentifier
-        }
-        stream {
-            streamName
-            streamSource
-        }
-    }
+	set(id: $id) {
+		id
+		event {
+			hasTasks
+			videogame {
+				id
+			}
+			isOnline
+		}
+		fullRoundText
+		round
+		state
+		totalGames
+		entrant1Score
+		entrant2Score
+		slots {
+			entrant {
+				id
+				name
+				initialSeedNum
+				participants {
+					id
+					user {
+						id
+						slug
+						name
+						genderPronoun
+						authorizations(types: [TWITTER]) {
+							type
+							externalUsername
+						}
+						location {
+							city
+							country
+							state
+						}
+						images(type: "profile") {
+							url
+						}
+					}
+					player {
+						id
+						gamerTag
+						prefix
+						sets(page: 1, perPage: 1) {
+							nodes {
+								games {
+									selections {
+										entrant {
+											participants {
+												player {
+													id
+												}
+											}
+										}
+										selectionValue
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		games {
+			selections {
+				entrant {
+					id
+					participants {
+						player {
+							id
+						}
+					}
+				}
+				selectionValue
+			}
+			winnerId
+		}
+		phaseGroup {
+			phase {
+				name
+				groupCount
+				bracketType
+				progressionsOut {
+					id
+				}
+			}
+			displayIdentifier
+		}
+		stream {
+			streamName
+			streamSource
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGSetsQuery.txt
+++ b/src/TournamentDataProvider/StartGGSetsQuery.txt
@@ -1,51 +1,51 @@
 query EventMatchListQuery($eventSlug: String!, $page: Int = 1, $filters: SetFilters = {}, $perPage: Int = 256) {
-  event(slug: $eventSlug) {
-    sets(page: $page, perPage: $perPage, sortType: MAGIC, filters: $filters) {
-      pageInfo {
-        page
-        total
-        perPage
-        totalPages
-        sortBy
-      }
-      nodes {
-        id
-        identifier
-        round
-        fullRoundText
-        state
-        entrant1Score
-        entrant2Score
-        event {
-          numEntrants
-        }
-        slots {
-            entrant {
-                name
-                participants {
-                    player {
-                        gamerTag
-                        prefix
-                    }
-                }
-            }
-        }
-        phaseGroup {
-            displayIdentifier
-            phase {
-              name
-              groupCount
-              numSeeds
-            }
-        }
-        stream {
-          streamName
-          streamSource
-        }
-        station {
-          number
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		sets(page: $page, perPage: $perPage, sortType: MAGIC, filters: $filters) {
+			pageInfo {
+				page
+				total
+				perPage
+				totalPages
+				sortBy
+			}
+			nodes {
+				id
+				identifier
+				round
+				fullRoundText
+				state
+				entrant1Score
+				entrant2Score
+				event {
+					numEntrants
+				}
+				slots {
+					entrant {
+						name
+						participants {
+							player {
+								gamerTag
+								prefix
+							}
+						}
+					}
+				}
+				phaseGroup {
+					displayIdentifier
+					phase {
+						name
+						groupCount
+						numSeeds
+					}
+				}
+				stream {
+					streamName
+					streamSource
+				}
+				station {
+					number
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGStationSetsQuery.txt
+++ b/src/TournamentDataProvider/StartGGStationSetsQuery.txt
@@ -1,18 +1,18 @@
 query StationSetsQuery($eventSlug: String!, $filters: SetFilters = {}) {
-  event(slug: $eventSlug) {
-    sets(page: 1, perPage: 999, filters: $filters) {
-      nodes {
-        id
-        state
-        slots {
-          entrant {
-            id
-          }
-        }
-        station {
-          id
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		sets(page: 1, perPage: 999, filters: $filters) {
+			nodes {
+				id
+				state
+				slots {
+					entrant {
+						id
+					}
+				}
+				station {
+					id
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGStationsQuery.txt
+++ b/src/TournamentDataProvider/StartGGStationsQuery.txt
@@ -1,28 +1,28 @@
 query Stations($eventSlug: String!) {
-  event(slug: $eventSlug) {
-    stations(page: 1, perPage: 999) {
-      nodes {
-        id
-        clusterNumber
-        clusterPrefix
-        enabled
-        identifier
-        number
-        prefix
-        queueDepth
-        state
-        streamId
-      }
-    }
-    tournament {
-      streamQueue {
-        id
-        stream {
-          id
-          streamName
-          streamSource
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		stations(page: 1, perPage: 999) {
+			nodes {
+				id
+				clusterNumber
+				clusterPrefix
+				enabled
+				identifier
+				number
+				prefix
+				queueDepth
+				state
+				streamId
+			}
+		}
+		tournament {
+			streamQueue {
+				id
+				stream {
+					id
+					streamName
+					streamSource
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGStreamQueueQuery.txt
+++ b/src/TournamentDataProvider/StartGGStreamQueueQuery.txt
@@ -1,68 +1,68 @@
 query StreamQueueQuery($slug: String) {
-    event(slug: $slug){
-        slug
-        tournament {
-            streamQueue {
-                sets {
-                    id
-                    identifier
-                    fullRoundText
-                    totalGames
-                    state
-                    station {
-                      number
-                    }
-                    event {
-                        slug
-                    }
-                    slots {
-                        entrant {
-                            id
-                            name
-                            seeds {
-                                seedNum
-                            }
-                            participants {
-                                id
-                                user {
-                                    id
-                                    slug
-                                    name
-                                    genderPronoun
-                                    location {
-                                        city
-                                        country
-                                        state
-                                    }
-                                    images(type: "profile") {
-                                        url
-                                    }
-                                    authorizations(types: [TWITTER]) {
-                                        type
-                                        externalUsername
-                                    }
-                                }
-                                player {
-                                    id
-                                    gamerTag
-                                    prefix
-                                }
-                            }
-                        }
-                    }
-                    phaseGroup {
-                        displayIdentifier
-                        phase {
-                            name
-                            groupCount
-                        }
-                    }
-                }
-                stream {
-                    streamName
-                    streamSource
-                }
-            }
-        }
-    }
+	event(slug: $slug){
+		slug
+		tournament {
+			streamQueue {
+				sets {
+					id
+					identifier
+					fullRoundText
+					totalGames
+					state
+					station {
+					  number
+					}
+					event {
+						slug
+					}
+					slots {
+						entrant {
+							id
+							name
+							seeds {
+								seedNum
+							}
+							participants {
+								id
+								user {
+									id
+									slug
+									name
+									genderPronoun
+									location {
+										city
+										country
+										state
+									}
+									images(type: "profile") {
+										url
+									}
+									authorizations(types: [TWITTER]) {
+										type
+										externalUsername
+									}
+								}
+								player {
+									id
+									gamerTag
+									prefix
+								}
+							}
+						}
+					}
+					phaseGroup {
+						displayIdentifier
+						phase {
+							name
+							groupCount
+						}
+					}
+				}
+				stream {
+					streamName
+					streamSource
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGStreamSetsQuery.txt
+++ b/src/TournamentDataProvider/StartGGStreamSetsQuery.txt
@@ -1,20 +1,20 @@
 query StreamSetsQuery($eventSlug: String!) {
-  event(slug: $eventSlug) {
-    id
-    tournament {
-        streamQueue {
-            sets {
-                id
-                state
-                event {
-                  id
-                }
-            }
-            stream {
-                streamName
-                streamSource
-            }
-        }
-    }
-  }
+	event(slug: $eventSlug) {
+		id
+		tournament {
+			streamQueue {
+				sets {
+					id
+					state
+					event {
+						id
+					}
+				}
+				stream {
+					streamName
+					streamSource
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentDataQuery.txt
@@ -1,21 +1,21 @@
 query TournamentDataQuery($eventSlug: String!) {
-  event(slug: $eventSlug) {
-    id
-    videogame {
-      id
-      name
-    }
-    isOnline
-    name
-    numEntrants
-    startAt
-    endAt
-    tournament {
-        name
-        shortSlug
-        venueAddress
-        startAt
-        endAt
-    }
-  }
+	event(slug: $eventSlug) {
+		id
+		videogame {
+			id
+			name
+		}
+		isOnline
+		name
+		numEntrants
+		startAt
+		endAt
+		tournament {
+			name
+			shortSlug
+			venueAddress
+			startAt
+			endAt
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGTournamentPhaseGroupQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentPhaseGroupQuery.txt
@@ -1,76 +1,76 @@
 query TournamentPhaseGroupQuery($id: ID!, $videogameId: ID) {
-  phaseGroup(id: $id) {
-    seedMap
-    seeds(query: {page: 1, perPage: 500}) {
-      nodes {
-        seedNum
-        progressionSource {
-          originPhaseGroup {
-            id
-          }
-        }
-        entrant {
-          id
-          name
-          participants {
-            player {
-              id
-              gamerTag
-              prefix
-              name
-              sets(page: 1, perPage: 1, filters: { hideEmpty: true, videogameId: $videogameId, videogameIds: [$videogameId] }) {
-                nodes {
-                  games {
-                    selections {
-                      entrant {
-                        participants {
-                          player {
-                            id
-                          }
-                        }
-                      }
-                      selectionValue
-                    }
-                  }
-                }
-              }
-            }
-            user {
-              id
-              prefix
-              name
-              genderPronoun
-              location {
-                country
-                state
-                city
-              }
-              authorizations(types: [TWITTER]) {
-                externalUsername
-              }
-              images(type: "profile") {
-                url
-              }
-            }
-          }
-        }
-      }
-    }
-    sets(page: 1, perPage: 9999, filters: {showByes: true, hideEmpty: false}, sortType: CALL_ORDER){
-      nodes {
-        id
-        round
-        identifier
-        entrant1Score
-        entrant2Score
-        state
-        slots {
-          prereqType
-        }
-      }
-    }
-    progressionsOut {
-      id
-    }
-  }
+	phaseGroup(id: $id) {
+		seedMap
+		seeds(query: {page: 1, perPage: 500}) {
+			nodes {
+				seedNum
+				progressionSource {
+					originPhaseGroup {
+						id
+					}
+				}
+				entrant {
+					id
+					name
+					participants {
+						player {
+							id
+							gamerTag
+							prefix
+							name
+							sets(page: 1, perPage: 1, filters: { hideEmpty: true, videogameId: $videogameId, videogameIds: [$videogameId] }) {
+								nodes {
+									games {
+										selections {
+											entrant {
+												participants {
+													player {
+														id
+													}
+												}
+											}
+											selectionValue
+										}
+									}
+								}
+							}
+						}
+						user {
+							id
+							prefix
+							name
+							genderPronoun
+							location {
+								country
+								state
+								city
+							}
+							authorizations(types: [TWITTER]) {
+								externalUsername
+							}
+							images(type: "profile") {
+								url
+							}
+						}
+					}
+				}
+			}
+		}
+		sets(page: 1, perPage: 9999, filters: {showByes: true, hideEmpty: false}, sortType: CALL_ORDER){
+			nodes {
+				id
+				round
+				identifier
+				entrant1Score
+				entrant2Score
+				state
+				slots {
+					prereqType
+				}
+			}
+		}
+		progressionsOut {
+			id
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGTournamentPhasesQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentPhasesQuery.txt
@@ -1,15 +1,15 @@
 query TournamentPhasesQuery($eventSlug: String!) {
-  event(slug: $eventSlug) {
-    phases {
-      id
-      name
-      phaseGroups(query: {page: 1, perPage: 99}){
-        nodes {
-          id
-          displayIdentifier
-          bracketType
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		phases {
+			id
+			name
+			phaseGroups(query: {page: 1, perPage: 99}){
+				nodes {
+					id
+					displayIdentifier
+					bracketType
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGTournamentStandingsQuery.txt
+++ b/src/TournamentDataProvider/StartGGTournamentStandingsQuery.txt
@@ -1,53 +1,53 @@
 query TournamentStandingsQuery($eventSlug: String!, $playerNumber: Int!) {
-  event(slug: $eventSlug) {
-    standings(query: {page: 1, perPage: $playerNumber}) {
-      nodes {
-        entrant {
-          id
-          name
-          participants {
-            player {
-              id
-              gamerTag
-              prefix
-              name
-            }
-            user {
-              id
-              prefix
-              name
-              genderPronoun
-              location {
-                country
-                state
-                city
-              }
-              authorizations(types: [TWITTER]) {
-                externalUsername
-              }
-              images(type: "profile") {
-                url
-              }
-            }
-          }
-          paginatedSets(page: 1, perPage: 64, sortType: RECENT, filters: { hideEmpty: true }) {
-            nodes {
-              games {
-                selections {
-                  entrant {
-                    participants {
-                      player {
-                        id
-                      }
-                    }
-                  }
-                  selectionValue
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+	event(slug: $eventSlug) {
+		standings(query: {page: 1, perPage: $playerNumber}) {
+			nodes {
+				entrant {
+					id
+					name
+					participants {
+						player {
+							id
+							gamerTag
+							prefix
+							name
+						}
+						user {
+							id
+							prefix
+							name
+							genderPronoun
+							location {
+								country
+								state
+								city
+							}
+							authorizations(types: [TWITTER]) {
+								externalUsername
+							}
+							images(type: "profile") {
+								url
+							}
+						}
+					}
+					paginatedSets(page: 1, perPage: 64, sortType: RECENT, filters: { hideEmpty: true }) {
+						nodes {
+							games {
+								selections {
+									entrant {
+										participants {
+											player {
+												id
+											}
+										}
+									}
+									selectionValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/StartGGUserSetQuery.txt
+++ b/src/TournamentDataProvider/StartGGUserSetQuery.txt
@@ -1,27 +1,27 @@
 query UserSetQuery($userSlug: String!, $filters: SetFilters = {}) {
-    user(slug: $userSlug) {
-        player {
-            id
-            sets(page: 1, perPage: 1, filters: $filters) {
-                nodes {
-                    id
-                    slots {
-                        entrant {
-                            participants {
-                                player {
-                                    id
-                                }
-                            }
-                        }
-                    }
-                    event {
-                        slug
-                        videogame {
-                            id
-                        }
-                    }
-                }
-            }
-        }
-    }
+	user(slug: $userSlug) {
+		player {
+			id
+			sets(page: 1, perPage: 1, filters: $filters) {
+				nodes {
+					id
+					slots {
+						entrant {
+							participants {
+								player {
+									id
+								}
+							}
+						}
+					}
+					event {
+						slug
+						videogame {
+							id
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/TournamentDataProvider/TournamentDataProvider.py
+++ b/src/TournamentDataProvider/TournamentDataProvider.py
@@ -54,6 +54,9 @@ class TournamentDataProvider:
     def GetLastSets(self, playerId, playerNumber):
         pass
 
+    def GetCompletedSets(self, progress_callback=None, cancel_event=None):
+        pass
+
     def GetPlayerHistoryStandings(self, playerId, playerNumber, gameType):
         pass
 

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -458,31 +458,55 @@ class Window(QMainWindow):
         hbox.addWidget(self.unsetTournamentBt)
 
         # Follow startgg user
+        if not SettingsManager.Get("general.hide_track_player", False):
+            hbox = QHBoxLayout()
+            group_box.layout().addLayout(hbox)
+
+            self.btLoadPlayerSet = QPushButton(
+                QApplication.translate("app", "Load tournament and sets from StartGG user"))
+            self.btLoadPlayerSet.setIcon(QIcon("./assets/icons/startgg.svg"))
+            self.btLoadPlayerSet.clicked.connect(self.LoadUserSetClicked)
+            self.btLoadPlayerSet.setIcon(QIcon("./assets/icons/startgg.svg"))
+            hbox.addWidget(self.btLoadPlayerSet)
+
+            TSHTournamentDataProvider.instance.signals.user_updated.connect(
+                self.UpdateUserSetButton)
+            TSHTournamentDataProvider.instance.signals.tournament_changed.connect(
+                self.UpdateUserSetButton)
+
+            self.btLoadPlayerSetOptions = QPushButton()
+            self.btLoadPlayerSetOptions.setSizePolicy(
+                QSizePolicy.Maximum, QSizePolicy.Maximum)
+            self.btLoadPlayerSetOptions.setIcon(
+                QIcon("./assets/icons/settings.svg"))
+            self.btLoadPlayerSetOptions.clicked.connect(
+                self.LoadUserSetOptionsClicked)
+            hbox.addWidget(self.btLoadPlayerSetOptions)
+
+            self.UpdateUserSetButton()
+        
+        # Completed Sets Feature
         hbox = QHBoxLayout()
         group_box.layout().addLayout(hbox)
-
-        self.btLoadPlayerSet = QPushButton(
-            QApplication.translate("app", "Load tournament and sets from StartGG user"))
-        self.btLoadPlayerSet.setIcon(QIcon("./assets/icons/startgg.svg"))
-        self.btLoadPlayerSet.clicked.connect(self.LoadUserSetClicked)
-        self.btLoadPlayerSet.setIcon(QIcon("./assets/icons/startgg.svg"))
-        hbox.addWidget(self.btLoadPlayerSet)
-
-        TSHTournamentDataProvider.instance.signals.user_updated.connect(
-            self.UpdateUserSetButton)
-        TSHTournamentDataProvider.instance.signals.tournament_changed.connect(
-            self.UpdateUserSetButton)
-
-        self.btLoadPlayerSetOptions = QPushButton()
-        self.btLoadPlayerSetOptions.setSizePolicy(
+        self.btPullCompletedSets = QPushButton(
+            QApplication.translate("app", "Pull Latest Completed Sets from StartGG"))
+        self.btPullCompletedSets.setIcon(QIcon("./assets/icons/startgg.svg"))
+        hbox.addWidget(self.btPullCompletedSets)
+        label_margin = " "*18
+        label = QLabel(
+            label_margin + QApplication.translate("app", "Time until Completed Sets refresh:") + " ")
+        label.setSizePolicy(QSizePolicy.Policy.Fixed,
+                            QSizePolicy.Policy.Minimum)
+        hbox.addWidget(label)
+        self.labelSetsTimer = QLabel(QApplication.translate("app", "Disabled"))
+        self.labelSetsTimer.setSizePolicy(QSizePolicy.Policy.Fixed,
+                            QSizePolicy.Policy.Minimum)
+        hbox.addWidget(self.labelSetsTimer)
+        self.btStopSetsPull = QPushButton()
+        self.btStopSetsPull.setSizePolicy(
             QSizePolicy.Maximum, QSizePolicy.Maximum)
-        self.btLoadPlayerSetOptions.setIcon(
-            QIcon("./assets/icons/settings.svg"))
-        self.btLoadPlayerSetOptions.clicked.connect(
-            self.LoadUserSetOptionsClicked)
-        hbox.addWidget(self.btLoadPlayerSetOptions)
-
-        self.UpdateUserSetButton()
+        self.btStopSetsPull.setIcon(QIcon("./assets/icons/cancel.svg"))
+        hbox.addWidget(self.btStopSetsPull)
 
         # Settings
         menu_margin = " "*6
@@ -823,6 +847,9 @@ class Window(QMainWindow):
             )
             TSHTournamentDataProvider.instance.LoadUserSet(
                 self.scoreboard.GetScoreboard(1), SettingsManager.Get("StartGG_user"))
+    
+    def LoadCompletedSetsClicked(self):
+        logger.info("PUSHED!")
 
     def LoadUserSetOptionsClicked(self):
         TSHTournamentDataProvider.instance.SetUserAccount(


### PR DESCRIPTION
This PR marks the addition of the completed sets feature to pull the last 10 completed sets in the current provided event, as well as a few other noteworthy additions/changes.

- The ability to hide the StartGG player tracking feature in TSH (Not as used and can be hidden for more screen space)
- Widget default display options! (Now you can hide pesky items that take up too much of your screen real estate that you don't use)
- Reformatted StartGG queries to use tabs over spaces (I know this may be controversial to some devs, but it makes it easier to edit in normal editors in my opinion when we expand/add new features, such as Completed Sets)

_This PR will remain in Draft status until I finish it up, just wanted to keep a copy of my work elsewhere as a precaution._