### PR TITLE
Gitignoring temp assets dirs in case they stay somehow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ Pipfile*
 env
 desktop.ini
 assets/controller/*
+assets/*_tmp


### PR DESCRIPTION
Added all assets/*_tmp directories to gitignore, to avoid unnecessary annoyance when they survive deletion