### PR TITLE
Webserver : send js files with appr. MIME type

### DIFF
--- a/src/TSHWebServer.py
+++ b/src/TSHWebServer.py
@@ -537,10 +537,13 @@ class WebServer(QThread):
     @app.route('/', defaults=dict(filename=None))
     @app.route('/<path:filename>', methods=['GET', 'POST'])
     @cross_origin()
-    def test(filename):
+    def file_request(filename):
         try:
             filename = filename or 'stage_strike_app/build/index.html'
-            return send_from_directory(os.path.abspath('.'), filename, as_attachment=filename.endswith('.gz'))
+            mimetype = None
+            if filename.endswith('.js'):
+                mimetype = "text/javascript"
+            return send_from_directory(os.path.abspath('.'), filename, as_attachment=filename.endswith('.gz'), mimetype=mimetype)
         except Exception as e:
             logger.error(f"File not found: {e}")
 


### PR DESCRIPTION
When asked to send a JS file, the webserver sets the appropriate Content-Type : "text/javascript".  
This prevents issues with Firefox sometimes refusing to load scripts because of the incorrect MIME type received. 

Currently, this does not work for ALL js files : files loaded from the layout/include directory (and only those) have the default MIME type. I have no idea why, but it does not cause issues anyways because loading these files with the incorrect type did not cause issues in the first place. I guess this has to see with these scripts being loaded as CJS vs EJS.

I also changed the name of the function bound to the flash route for returning files, because it was still named "test"