### PR TITLE
Don't redownload the controllers file on every launch

### DIFF
--- a/src/Helpers/TSHControllerHelper.py
+++ b/src/Helpers/TSHControllerHelper.py
@@ -3,7 +3,9 @@ from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 import requests
 import os
+import pathlib
 import shutil
+import time
 import traceback
 import zipfile
 import json
@@ -32,6 +34,14 @@ class TSHControllerHelper(QObject):
 
     def UpdateControllerFile(self):
         try:
+            out_dir = pathlib.Path('./assets/controller')
+
+            if out_dir.exists():
+                modtime = out_dir.stat().st_mtime
+                if time.time() - modtime <= (12 * 60 * 60):
+                    logger.debug("Skipping controller db download.")
+                    return
+
             url = 'https://github.com/Wolfy76700/ControllerDatabase/archive/refs/heads/main.zip'
             r = requests.get(url, allow_redirects=True)
 


### PR DESCRIPTION
I noticed that TSH was downloading almost 100MB on every launch downloading the controllers db. This PR makes it use a 12h timeout for redownloading the archive. This is the same behavior used for downloading the countries file.