### PR TITLE
Make Default Team colors changeable and add the ability to use colors in the settings widget

### DIFF
--- a/src/Settings/SettingsWidget.py
+++ b/src/Settings/SettingsWidget.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import *
-from ..TSHHotkeys import TSHHotkeys
+from ..TSHColorButton import TSHColorButton
 from ..SettingsManager import SettingsManager
 import textwrap
 
@@ -71,6 +71,16 @@ class SettingsWidget(QWidget):
             resetButton.clicked.connect(
                 lambda bt=None, setting=setting, settingWidget=settingWidget: [
                     settingWidget.setText(defaultValue),
+                    callback()
+                ]
+            )
+        elif type == "color":
+            settingWidget = TSHColorButton(color=SettingsManager.Get(self.settingsBase+"."+setting, defaultValue), disable_right_click=True)
+            settingWidget.colorChanged.connect(
+                lambda val=None: SettingsManager.Set(self.settingsBase+"."+setting, settingWidget.color()))
+            resetButton.clicked.connect(
+                lambda bt=None, setting=setting, settingWidget=settingWidget: [
+                    settingWidget.setColor(defaultValue),
                     callback()
                 ]
             )

--- a/src/Settings/TSHSettingsWindow.py
+++ b/src/Settings/TSHSettingsWindow.py
@@ -88,10 +88,26 @@ class TSHSettingsWindow(QDialog):
 
         generalSettings.append((
             QApplication.translate(
-                "settings.disable_country_file_downloading", "Disables attempting to download the country and states file (takes effect on next restart, should prevent weird loading issues with updates)"),
+                "settings.disable_country_file_downloading", "Disables attempting to download the country and states file (takes effect on next restart)"),
             "disable_country_file_downloading",
             "checkbox",
             False
+        ))
+
+        generalSettings.append((
+            QApplication.translate(
+                "settings.team_1_default_color", "Default Color of Team 1"),
+            "team_1_default_color",
+            "color",
+            "#fe3636"
+        ))
+
+        generalSettings.append((
+            QApplication.translate(
+                "settings.team_2_default_color", "Default Color of Team 2"),
+            "team_2_default_color",
+            "color",
+            "#2e89ff"
         ))
 
         self.add_setting_widget(QApplication.translate(

--- a/src/TSHColorButton.py
+++ b/src/TSHColorButton.py
@@ -16,11 +16,12 @@ class TSHColorButton(QToolButton):
 
     colorChanged = Signal(object)
 
-    def __init__(self, *args, color=None, **kwargs):
+    def __init__(self, *args, color=None, disable_right_click=False, **kwargs):
         super(TSHColorButton, self).__init__(*args, **kwargs)
 
         self._color = None
         self._default = color
+        self.disable_right_click = disable_right_click
         self.pressed.connect(self.onColorPicker)
 
         # Set the initial/default state.
@@ -32,7 +33,7 @@ class TSHColorButton(QToolButton):
             self.colorChanged.emit(color)
 
         if self._color:
-            self.setStyleSheet("background-color: %s;" % self._color)
+            self.setStyleSheet("QToolButton { background-color: %s; }" % self._color)
         else:
             self.setStyleSheet("")
 
@@ -47,7 +48,6 @@ class TSHColorButton(QToolButton):
 
         '''
         dlg = QColorDialog(self)
-        dlg.setStyleSheet("* { background-color: rgb(41, 41, 41); }")
         if self._color:
             dlg.setCurrentColor(QColor(self._color))
 
@@ -55,7 +55,7 @@ class TSHColorButton(QToolButton):
             self.setColor(dlg.currentColor().name())
 
     def mousePressEvent(self, e):
-        if e.button() == Qt.RightButton:
+        if not self.disable_right_click and e.button() == Qt.RightButton:
             self.setColor(self._default)
 
         return super(TSHColorButton, self).mousePressEvent(e)

--- a/src/TSHScoreboardManager.py
+++ b/src/TSHScoreboardManager.py
@@ -4,6 +4,7 @@ from qtpy.QtWidgets import *
 from loguru import logger
 
 from .TSHScoreboardWidget import TSHScoreboardWidget
+from .SettingsManager import SettingsManager
 from .StateManager import StateManager
 
 
@@ -46,9 +47,9 @@ class TSHScoreboardManager(QDockWidget):
                     "Scoreboard Manager - Creating Scoreboard " + str(amount))
 
                 if int(amount)-1 == 1:
-                    self.GetScoreboard(1).btLoadPlayerSet.setHidden(True)
-                    self.GetScoreboard(
-                        1).btLoadPlayerSetOptions.setHidden(True)
+                    if not SettingsManager.Get("general.hide_track_player", False):
+                        self.GetScoreboard(1).btLoadPlayerSet.setHidden(True)
+                        self.GetScoreboard(1).btLoadPlayerSetOptions.setHidden(True)
 
                 scoreboard = QWidget()
                 scoreboard.setLayout(QVBoxLayout())
@@ -64,9 +65,9 @@ class TSHScoreboardManager(QDockWidget):
                 self.scoreboardholder[amount].deleteLater()
                 self.scoreboardholder.pop(amount)
                 if int(amount) == 1:
-                    self.GetScoreboard(1).btLoadPlayerSet.setHidden(False)
-                    self.GetScoreboard(
-                        1).btLoadPlayerSetOptions.setHidden(False)
+                    if not SettingsManager.Get("general.hide_track_player", False):
+                        self.GetScoreboard(1).btLoadPlayerSet.setHidden(False)
+                        self.GetScoreboard(1).btLoadPlayerSetOptions.setHidden(False)
                 StateManager.Unset(f"score.{amount+1}")
         finally:
             StateManager.ReleaseSaving()

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -351,13 +351,14 @@ class TSHScoreboardWidget(QWidget):
         self.team1column.findChild(QLabel, "teamLabel").setText(
             QApplication.translate("app", "TEAM {0}").format(1))
 
-        DEFAULT_TEAM1_COLOR = 'rgb(254, 54, 54)'
-
+        DEFAULT_TEAM1_COLOR = SettingsManager.Get("general.team_1_default_color", "#fe3636")
         self.colorButton1 = TSHColorButton(color=DEFAULT_TEAM1_COLOR)
         # self.colorButton1.setText(QApplication.translate("app", "COLOR"))
         self.colorButton1.colorChanged.connect(
             lambda color: [
-                self.CommandTeamColor(0, color)
+                StateManager.BlockSaving(),
+                StateManager.Set(f"score.{self.scoreboardNumber}.team.1.color", color),
+                StateManager.ReleaseSaving()
             ])
         self.CommandTeamColor(0, DEFAULT_TEAM1_COLOR)
 
@@ -391,15 +392,17 @@ class TSHScoreboardWidget(QWidget):
         self.team2column.findChild(QLabel, "teamLabel").setText(
             QApplication.translate("app", "TEAM {0}").format(2))
 
-        DEFAULT_TEAM2_COLOR = 'rgb(46, 137, 255)'
-
+        DEFAULT_TEAM2_COLOR = SettingsManager.Get("general.team_2_default_color", "#2e89ff")
         self.colorButton2 = TSHColorButton(color=DEFAULT_TEAM2_COLOR)
         self.colorButton2.colorChanged.connect(
             lambda color: [
-                self.CommandTeamColor(1, color)
+                StateManager.BlockSaving(),
+                StateManager.Set(f"score.{self.scoreboardNumber}.team.2.color", color),
+                StateManager.ReleaseSaving()
             ])
         # self.colorButton2.setText(QApplication.translate("app", "COLOR"))
         self.CommandTeamColor(1, DEFAULT_TEAM2_COLOR)
+
         self.team2column.findChild(QHBoxLayout, "horizontalLayout_2").layout(
         ).insertWidget(0, self.colorButton2)
 

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -1117,12 +1117,13 @@ class Window(QMainWindow):
             qdarktheme.setup_theme()
 
     def ToggleTopOption(self):
-        if TSHScoreboardManager.instance.GetTabAmount() > 1:
-            self.btLoadPlayerSet.setHidden(True)
-            self.btLoadPlayerSetOptions.setHidden(True)
-        else:
-            self.btLoadPlayerSet.setHidden(False)
-            self.btLoadPlayerSetOptions.setHidden(False)
+        if not SettingsManager.Get("general.hide_track_player", False):
+            if TSHScoreboardManager.instance.GetTabAmount() > 1:
+                self.btLoadPlayerSet.setHidden(True)
+                self.btLoadPlayerSetOptions.setHidden(True)
+            else:
+                self.btLoadPlayerSet.setHidden(False)
+                self.btLoadPlayerSetOptions.setHidden(False)
 
     def ChangeTab(self):
         tabNameWindow = QDialog(self)


### PR DESCRIPTION
- The default team colors are now changeable via the Settings menu.
- Colors are now able to be used as settings!
- The "Ok" button in the color picker dialog now displays as it should at long last.
- Fixed an oversight in hiding the player tracking feature (my bad).