### PR TITLE
Reverted states to always use their ISO 3166-2 code

### DIFF
--- a/src/Helpers/TSHCountryHelper.py
+++ b/src/Helpers/TSHCountryHelper.py
@@ -143,8 +143,7 @@ class TSHCountryHelper(QObject):
                         if s.get("state_code") is None:
                             continue
 
-                        scode = s.get("state_code") if not s.get("state_code").isdigit() else "".join([
-                            word[0] for word in re.split(r'\s+|-', s.get("name").strip()) if len(word) > 0])
+                        scode = s.get("state_code")
 
                         TSHCountryHelper.countries[c["iso2"]]["states"][s["state_code"]] = {
                             "name": s.get("name"),


### PR DESCRIPTION
- Reverted states to always use their ISO 3166-2 code
  - This fixes saving conflicts when two states have the same initials (https://github.com/joaorb64/TournamentStreamHelper/issues/751) while also keeping it in line with international naming conventions