### PR TITLE
Fix players-per-team + characters-per-player causing state corruption

### DIFF
--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 
 import orjson
@@ -31,6 +32,14 @@ class StateManager:
     lock = threading.RLock()
     threads = []
     loop = None
+
+    @contextlib.contextmanager
+    def SaveBlock():
+        StateManager.BlockSaving()
+        try:
+            yield
+        finally:
+            StateManager.ReleaseSaving()
 
     def BlockSaving():
         StateManager.saveBlocked += 1
@@ -112,7 +121,10 @@ class StateManager:
             StateManager.SaveState()
 
     def Set(key: str, value):
-        # logger.debug(f"StateManager Setting {key} to {value}")
+        # import inspect
+        # func = inspect.currentframe().f_back.f_code
+        # fname = os.path.split(func.co_filename)[1]
+        # logger.debug(f"{func.co_name}({fname}:{func.co_firstlineno}) Setting {key} to {value}")
         with StateManager.lock:
             # StateManager.lastSavedState = deep_clone(StateManager.state)
 
@@ -129,6 +141,11 @@ class StateManager:
                 # StateManager.ExportText(oldState)
 
     def Unset(key: str):
+        # import inspect
+        # func = inspect.currentframe().f_back.f_code
+        # fname = os.path.split(func.co_filename)[1]
+        # logger.debug(f"{func.co_name}({fname}:{func.co_firstlineno}) Deleting {key}")
+
         with StateManager.lock:
             # StateManager.lastSavedState = deep_clone(StateManager.state)
             deep_unset(StateManager.state, key)

--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -86,80 +86,81 @@ class TSHGameAssetManager(QObject):
     def LoadGames(self):
         class GameLoaderThread(QThread):
             def run(self):
-                self.parent().games = {}
+                with StateManager.SaveBlock():
+                    self.parent().games = {}
 
-                gameDirs = os.listdir("./user_data/games/")
+                    gameDirs = os.listdir("./user_data/games/")
 
-                for game in gameDirs:
-                    if os.path.isfile("./user_data/games/"+game+"/base_files/config.json"):
-                        with open("./user_data/games/"+game +
-                                  "/base_files/config.json", "rb") as f:
-                            self.parent().games[game] = orjson.loads(f.read())
+                    for game in gameDirs:
+                        if os.path.isfile("./user_data/games/"+game+"/base_files/config.json"):
+                            with open("./user_data/games/"+game +
+                                      "/base_files/config.json", "rb") as f:
+                                self.parent().games[game] = orjson.loads(f.read())
 
-                        # Try logo_small, if it doesn't exist use logo
-                        if os.path.isfile("./user_data/games/"+game+"/base_files/logo_small.png"):
-                            self.parent().games[game]["logo"] = QIcon(
-                                QPixmap(
-                                    QImage("./user_data/games/"+game+"/base_files/logo_small.png").scaled(
-                                        64,
-                                        64,
-                                        Qt.AspectRatioMode.KeepAspectRatio,
-                                        Qt.TransformationMode.SmoothTransformation
+                            # Try logo_small, if it doesn't exist use logo
+                            if os.path.isfile("./user_data/games/"+game+"/base_files/logo_small.png"):
+                                self.parent().games[game]["logo"] = QIcon(
+                                    QPixmap(
+                                        QImage("./user_data/games/"+game+"/base_files/logo_small.png").scaled(
+                                            64,
+                                            64,
+                                            Qt.AspectRatioMode.KeepAspectRatio,
+                                            Qt.TransformationMode.SmoothTransformation
+                                        )
                                     )
                                 )
-                            )
-                        elif os.path.isfile("./user_data/games/"+game+"/base_files/logo.png"):
-                            self.parent().games[game]["logo"] = QIcon(
-                                QPixmap(
-                                    QImage("./user_data/games/"+game+"/base_files/logo.png").scaled(
-                                        64,
-                                        64,
-                                        Qt.AspectRatioMode.KeepAspectRatio,
-                                        Qt.TransformationMode.SmoothTransformation
+                            elif os.path.isfile("./user_data/games/"+game+"/base_files/logo.png"):
+                                self.parent().games[game]["logo"] = QIcon(
+                                    QPixmap(
+                                        QImage("./user_data/games/"+game+"/base_files/logo.png").scaled(
+                                            64,
+                                            64,
+                                            Qt.AspectRatioMode.KeepAspectRatio,
+                                            Qt.TransformationMode.SmoothTransformation
+                                        )
                                     )
                                 )
-                            )
 
-                        self.parent().games[game]["assets"] = {}
-                        self.parent(
-                        ).games[game]["path"] = "./user_data/games/"+game+"/"
+                            self.parent().games[game]["assets"] = {}
+                            self.parent(
+                            ).games[game]["path"] = "./user_data/games/"+game+"/"
 
-                        assetDirs = os.listdir("./user_data/games/"+game)
-                        assetDirs += ["base_files/" +
-                                      f for f in os.listdir("./user_data/games/"+game+"/base_files/")]
+                            assetDirs = os.listdir("./user_data/games/"+game)
+                            assetDirs += ["base_files/" +
+                                          f for f in os.listdir("./user_data/games/"+game+"/base_files/")]
 
-                        for dir in assetDirs:
-                            if os.path.isdir("./user_data/games/"+game+"/"+dir):
-                                if os.path.isfile("./user_data/games/"+game+"/"+dir+"/config.json"):
-                                    logger.info(
-                                        "Found asset config for ["+game+"]["+dir+"]")
-                                    with open("./user_data/games/"+game+"/"+dir +
-                                              "/config.json", "rb") as f:
-                                        self.parent().games[game]["assets"][dir] = \
-                                            orjson.loads(f.read())
-                                else:
-                                    logger.error(
-                                        "No config file for "+game+" - "+dir)
+                            for dir in assetDirs:
+                                if os.path.isdir("./user_data/games/"+game+"/"+dir):
+                                    if os.path.isfile("./user_data/games/"+game+"/"+dir+"/config.json"):
+                                        logger.info(
+                                            "Found asset config for ["+game+"]["+dir+"]")
+                                        with open("./user_data/games/"+game+"/"+dir +
+                                                  "/config.json", "rb") as f:
+                                            self.parent().games[game]["assets"][dir] = \
+                                                orjson.loads(f.read())
+                                    else:
+                                        logger.error(
+                                            "No config file for "+game+" - "+dir)
 
-                        # Load translated names
-                        # Translate game name
-                        locale = TSHLocaleHelper.programLocale
-                        if locale.replace('-', '_') in self.parent().games[game].get("locale", {}):
-                            game_name = self.parent(
-                            ).games[game]["locale"][locale.replace('-', '_')].get("name")
-                            if game_name:
-                                self.parent(
-                                ).games[game]["name"] = game_name
-                        elif locale.split('-')[0] in self.parent().games[game].get("locale", {}):
-                            game_name = self.parent(
-                            ).games[game]["locale"][locale.split('-')[0]].get("name")
-                            if game_name:
-                                self.parent(
-                                ).games[game]["name"] = game_name
-                    else:
-                        logger.info("Game config for "+game+" doesn't exist.")
-                # print(self.parent().games)
-                self.parent().signals.onLoadAssets.emit()
+                            # Load translated names
+                            # Translate game name
+                            locale = TSHLocaleHelper.programLocale
+                            if locale.replace('-', '_') in self.parent().games[game].get("locale", {}):
+                                game_name = self.parent(
+                                ).games[game]["locale"][locale.replace('-', '_')].get("name")
+                                if game_name:
+                                    self.parent(
+                                    ).games[game]["name"] = game_name
+                            elif locale.split('-')[0] in self.parent().games[game].get("locale", {}):
+                                game_name = self.parent(
+                                ).games[game]["locale"][locale.split('-')[0]].get("name")
+                                if game_name:
+                                    self.parent(
+                                    ).games[game]["name"] = game_name
+                        else:
+                            logger.info("Game config for "+game+" doesn't exist.")
+                    # print(self.parent().games)
+                    self.parent().signals.onLoadAssets.emit()
 
         gameLoaderThread = GameLoaderThread(self)
         gameLoaderThread.start()
@@ -498,19 +499,20 @@ class TSHGameAssetManager(QObject):
                         except:
                             logger.error(traceback.format_exc())
 
-                    StateManager.Set(f"game", {
-                        "name": self.parent().selectedGame.get("name"),
-                        "smashgg_id": self.parent().selectedGame.get("smashgg_game_id"),
-                        "codename": self.parent().selectedGame.get("codename"),
-                        "logo": self.parent().selectedGame.get("path", "")+"/base_files/logo.png",
-                        "defaults": self.parent().selectedGame.get("defaults"),
-                    })
+                    with StateManager.SaveBlock():
+                        StateManager.Set(f"game", {
+                            "name": self.parent().selectedGame.get("name"),
+                            "smashgg_id": self.parent().selectedGame.get("smashgg_game_id"),
+                            "codename": self.parent().selectedGame.get("codename"),
+                            "logo": self.parent().selectedGame.get("path", "")+"/base_files/logo.png",
+                            "defaults": self.parent().selectedGame.get("defaults"),
+                        })
 
-                    self.parent().UpdateCharacterModel()
-                    self.parent().UpdateSkinModel()
-                    self.parent().UpdateVariantModel()
-                    self.parent().UpdateStageModel()
-                    self.parent().signals.onLoad.emit()
+                        self.parent().UpdateCharacterModel()
+                        self.parent().UpdateSkinModel()
+                        self.parent().UpdateVariantModel()
+                        self.parent().UpdateStageModel()
+                        self.parent().signals.onLoad.emit()
                 except:
                     logger.error(traceback.format_exc())
                 finally:

--- a/src/TSHPlayerList.py
+++ b/src/TSHPlayerList.py
@@ -1,4 +1,5 @@
 
+from loguru import logger
 from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 from qtpy.QtCore import *
@@ -100,6 +101,7 @@ class TSHPlayerList(QWidget):
         StateManager.ReleaseSaving()
 
     def SetCharactersPerPlayer(self, value):
+        # logger.info("TSHPlayerList#SetCharactersPerPlayer")
         self.charactersPerPlayer = value
         StateManager.BlockSaving()
         self.childDataChangedLock = True
@@ -117,6 +119,7 @@ class TSHPlayerList(QWidget):
                 s.scoreWidget.setVisible(True)
 
     def SetPlayersPerTeam(self, number):
+        # logger.info("TSHPlayerList#SetPlayersPerTeam")
         self.playersPerTeam = number
         StateManager.BlockSaving()
         self.childDataChangedLock = True

--- a/src/TSHPlayerListSlotWidget.py
+++ b/src/TSHPlayerListSlotWidget.py
@@ -73,6 +73,7 @@ class TSHPlayerListSlotWidget(QGroupBox):
         self.playerWidgets = []
 
     def SetPlayersPerTeam(self, number):
+        # logger.info(f"TSHPlayerListSlotWidget#SetPlayersPerTeam({number})")
         if number != len(self.playerWidgets):
             StateManager.BlockSaving()
             while len(self.playerWidgets) < number:
@@ -116,6 +117,7 @@ class TSHPlayerListSlotWidget(QGroupBox):
             self.signals.dataChanged.emit()
 
     def SetCharacterNumber(self, value):
+        # logger.info(f"TSHPlayerListSlotWidget#SetCharacterNumber({value})")
         StateManager.BlockSaving()
         for pw in self.playerWidgets:
             pw.SetCharactersPerPlayer(value)

--- a/src/TSHPlayerListWidget.py
+++ b/src/TSHPlayerListWidget.py
@@ -150,23 +150,27 @@ class TSHPlayerListWidget(QDockWidget):
         messagebox.exec()
 
     def LoadFromStandings(self, data):
-        StateManager.BlockSaving()
-        if data is not None and len(data) > 0:
-            playerNumber = len(data[0].get("players"))
-            self.playerList.SetPlayersPerTeam(playerNumber)
+        with StateManager.SaveBlock():
+            if data is not None and len(data) > 0:
+                playerNumber = len(data[0].get("players"))
+                self.playerList.SetPlayersPerTeam(playerNumber)
 
-            for i, slot in enumerate(self.playerList.slotWidgets):
-                try:
-                    slot.SetTeamData(data[i])
-                except:
-                    slot.Clear()
-                    logger.error(traceback.format_exc())
-        StateManager.ReleaseSaving()
+                for i, slot in enumerate(self.playerList.slotWidgets):
+                    try:
+                        slot.SetTeamData(data[i])
+                    except:
+                        slot.Clear()
+                        logger.error(traceback.format_exc())
 
     def SetDefaultsFromAssets(self):
         if StateManager.Get(f'game.defaults'):
             players, characters = StateManager.Get(f'game.defaults.players_per_team', 1), StateManager.Get(f'game.defaults.characters_per_player', 1)
         else:
             players, characters = 1, 1
-        self.playerPerTeam.setValue(players)
-        self.charNumber.setValue(characters)
+
+        with StateManager.SaveBlock():
+            if self.playerList.playersPerTeam != players:
+                self.playerList.SetPlayersPerTeam(players)
+
+            if self.playerList.charactersPerPlayer != characters:
+                self.playerList.SetCharactersPerPlayer(characters)

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -1,6 +1,8 @@
 import os
 import re
 import traceback
+from typing import override
+
 from qtpy.QtGui import *
 from qtpy.QtWidgets import *
 from qtpy.QtCore import *
@@ -29,6 +31,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
     countries = None
     countryModel = None
     characterModel = None
+    _deleted = False
 
     signals = TSHScoreboardPlayerWidgetSignals()
 
@@ -197,12 +200,21 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         self.pronoun_completer.setModel(self.pronoun_model)
         self.pronoun_model.setStringList(self.pronoun_list)
 
+    @override
+    def deleteLater(self):
+        self._deleted = True
+        super().deleteLater()
+
     def ComboBoxIndexChanged(self, element: QComboBox):
         StateManager.Set(
             f"{self.path}.{element.objectName()}", element.currentData())
         self.instanceSignals.dataChanged.emit()
 
     def CharactersChanged(self, includeMains=False):
+        if self._deleted:
+            logger.warning(f"CharactersChanged called on deleted TSHScoreboardPlayerWidget for {self.path}")
+            return
+
         with self.dataLock:
             characters = {}
 
@@ -410,6 +422,7 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         self.teamNumber = team
 
     def SetCharactersPerPlayer(self, number):
+        # logger.info(f"TSHScoreboardPlayerWidget#SetCharactersPerPlayer({number})")
         while len(self.character_elements) < number:
             character_element = QWidget()
             character_element.setLayout(QHBoxLayout())

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -646,10 +646,12 @@ class TSHScoreboardWidget(QWidget):
             self.btSelectSet.setEnabled(False)
 
     def SetCharacterNumber(self, value):
+        # logger.info(f"TSHScoreboardWidget#SetCharacterNumber({value})")
         for pw in self.playerWidgets:
             pw.SetCharactersPerPlayer(value)
 
     def SetPlayersPerTeam(self, number):
+        # logger.info(f"TSHScoreboardWidget#SetPlayersPerTeam({number})")
         while len(self.team1playerWidgets) < number:
             p = TSHScoreboardPlayerWidget(
                 index=len(self.team1playerWidgets)+1,

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -935,23 +935,24 @@ class Window(QMainWindow):
 
     def ReloadGames(self):
         logger.info("Reload games")
-        self.gameSelect.setModel(QStandardItemModel())
-        self.gameSelect.addItem("", 0)
-        for i, game in enumerate(TSHGameAssetManager.instance.games.items()):
-            if game[1].get("name"):
-                self.gameSelect.addItem(game[1].get(
-                    "logo", QIcon()), game[1].get("name"), i+1)
-            else:
-                self.gameSelect.addItem(
-                    game[1].get("logo", QIcon()), game[0], i+1)
-        self.gameSelect.setIconSize(QSize(64, 64))
-        self.gameSelect.setFixedHeight(32)
-        view = QListView()
-        view.setIconSize(QSize(64, 64))
-        view.setStyleSheet("QListView::item { height: 32px; }")
-        self.gameSelect.setView(view)
-        self.gameSelect.model().sort(0)
-        self.SetGame()
+        with StateManager.SaveBlock():
+            self.gameSelect.setModel(QStandardItemModel())
+            self.gameSelect.addItem("", 0)
+            for i, game in enumerate(TSHGameAssetManager.instance.games.items()):
+                if game[1].get("name"):
+                    self.gameSelect.addItem(game[1].get(
+                        "logo", QIcon()), game[1].get("name"), i+1)
+                else:
+                    self.gameSelect.addItem(
+                        game[1].get("logo", QIcon()), game[0], i+1)
+            self.gameSelect.setIconSize(QSize(64, 64))
+            self.gameSelect.setFixedHeight(32)
+            view = QListView()
+            view.setIconSize(QSize(64, 64))
+            view.setStyleSheet("QListView::item { height: 32px; }")
+            self.gameSelect.setView(view)
+            self.gameSelect.model().sort(0)
+            self.SetGame()
 
     def DetectGameFromId(self, id):
         def detect_smashgg_id_match(games, game, id):


### PR DESCRIPTION
Fixed issues arising from changing characters-per-player and players-per-team at the same time. This actually was a python bug rather than a web UI bug where the state got corrupted from zombie objects still firing their signals and updating state that had already been deleted. I also in the course of tracking this issue down added a context manager for StateManager.BlockSaving, since I started out thinking I was debugging an issue with the web UI getting out of sync.

The underlying issue was something like this: imagine you have something like a playerListWidget that holds a collection called self.playerWidgets, the list widget will delete them like so:
```
self.playerWidgets.remove(currentWidget)
currentWidget.deleteLater() # (a Qt method)
```

The problem with this, is that all the playerWidget's signals are still connected until Qt sees fit to garbage collect the object, and worse, the object has no built-in way to inspect its own "deletion-scheduled" status. So what is happening here is the following sequence:
- Scoreboard changes # of players. This works correctly and removes excess player widgets from their associated lists and calls deleteLater() on them.
- Scoreboard changes # of characters per player. This sets a value on playerListWidget which then causes a signal to be emitted.
- All of the "live" playerWidgets AS WELL AS all of the waiting-to-be-deleted playerWidgets all catch the event and try to update their list of characters in the state.
- This re-creates the deleted path plus the character subpath (for example, setting score.1.team.1.player.3.character will have the side effect of re-creating the just-deleted score.1.team.1.player.3) for the player as a whole, leaving a blank player in the state.
- Web UI gracefully handles incomplete player data and shows extra player slots 🫠 .