### PR TITLE
Changed custom zoom in UI for icons to 1.0

### DIFF
--- a/src/TSHGameAssetManager.py
+++ b/src/TSHGameAssetManager.py
@@ -1214,7 +1214,10 @@ class TSHGameAssetManager(QObject):
                         "l" in uncropped_edge and
                         "r" in uncropped_edge
                     ):
-                        customZoom = 1.2  # Add zoom in for uncropped assets
+                        if "icon" in asset.get("type", []):
+                            customZoom = 1.0
+                        else:
+                            customZoom = 1.2  # Add zoom in for uncropped assets
                         minZoom = customZoom * proportional_zoom * rescalingFactor
                     elif (
                         not "l" in uncropped_edge and


### PR DESCRIPTION
- Changed custom zoom in UI for icons to 1.0
  - This fixes an issue where sometimes uncropped icon assets are zoomed in too close in the UI to be distinguishable