### PR TITLE
Test Fix StateManager exports permanently stopping after using the bracket widget

### DIFF
--- a/src/StateManager.py
+++ b/src/StateManager.py
@@ -33,6 +33,14 @@ class StateManager:
     threads = []
     loop = None
 
+    # Timestamp of the last 0 -> 1 transition of saveBlocked, used by the
+    # watchdog to detect a BlockSaving() that never got its ReleaseSaving().
+    saveBlockedSince = None
+
+    # If saving stays blocked for longer than this (seconds) while there are
+    # pending changes, we assume a block was leaked and force a save.
+    DEFAULT_BLOCK_WATCHDOG_SECONDS = 30
+
     # State paths whose subtrees are excluded from the out/ file export.
     # Use this for large lookup tables that are only useful as JSON (e.g. game.stages).
     EXPORT_EXCLUDED_PREFIXES = (
@@ -40,92 +48,189 @@ class StateManager:
     )
 
     @contextlib.contextmanager
-    def SaveBlock():
-        StateManager.BlockSaving()
+    def SaveBlock(watchdog=True):
+        StateManager.BlockSaving(watchdog=watchdog)
         try:
             yield
         finally:
             StateManager.ReleaseSaving()
 
-    def BlockSaving():
-        StateManager.saveBlocked += 1
-        if SettingsManager.Get("general.statemanager_logging", False):
-            logger.debug("Initial Block - Current Blocking Status: " + str(StateManager.saveBlocked))
+    def BlockSaving(watchdog=True):
+        # watchdog=False marks a block that is expected to be long lived (app
+        # startup), so the stuck-block watchdog doesn't fire on it.
+        with StateManager.lock:
+            StateManager.saveBlocked += 1
+            if StateManager.saveBlocked == 1:
+                StateManager.saveBlockedSince = time.time() if watchdog else None
+            if SettingsManager.Get("general.statemanager_logging", False):
+                logger.debug("Initial Block - Current Blocking Status: " + str(StateManager.saveBlocked))
 
     def ReleaseSaving():
-        StateManager.saveBlocked -= 1
-        if SettingsManager.Get("general.statemanager_logging", False):
-            logger.debug("Release Block - Current Blocking Status: " + str(StateManager.saveBlocked))
-        if StateManager.saveBlocked == 0:
+        with StateManager.lock:
+            StateManager.saveBlocked -= 1
+            if SettingsManager.Get("general.statemanager_logging", False):
+                logger.debug("Release Block - Current Blocking Status: " + str(StateManager.saveBlocked))
+
+            # More releases than blocks would leave the counter negative, which
+            # silently disables every future export just like a leaked block.
+            if StateManager.saveBlocked < 0:
+                logger.error(
+                    "StateManager save block counter went negative "
+                    f"({StateManager.saveBlocked}); there is a ReleaseSaving() "
+                    "without a matching BlockSaving(). Resetting to 0.")
+                StateManager.saveBlocked = 0
+
+            if StateManager.saveBlocked == 0:
+                StateManager.saveBlockedSince = None
+                StateManager.SaveState()
+
+    def ResetSaveBlock(reason: str):
+        """Force saving back to an unblocked state and export immediately.
+
+        Used to recover from an unbalanced BlockSaving() (usually an exception
+        thrown between BlockSaving() and ReleaseSaving()), which would
+        otherwise stop every export until the application is restarted.
+        """
+        with StateManager.lock:
+            if StateManager.saveBlocked == 0:
+                return
+            logger.error(
+                f"StateManager saving was stuck blocked ({StateManager.saveBlocked}): "
+                f"{reason}. Forcing a save.")
+            StateManager.saveBlocked = 0
+            StateManager.saveBlockedSince = None
             StateManager.SaveState()
 
+    def CheckSaveBlockWatchdog():
+        """Recover the export if saving has been blocked for too long."""
+        blockedSince = StateManager.saveBlockedSince
+
+        if StateManager.saveBlocked <= 0 or blockedSince is None:
+            return
+
+        timeout = SettingsManager.Get(
+            "general.statemanager_block_timeout",
+            StateManager.DEFAULT_BLOCK_WATCHDOG_SECONDS)
+
+        if timeout <= 0:
+            return
+
+        blockedFor = time.time() - blockedSince
+
+        if blockedFor > timeout:
+            StateManager.ResetSaveBlock(
+                f"saving has been blocked for {blockedFor:.1f}s, which points to a "
+                "BlockSaving() without a matching ReleaseSaving()")
+
     def SaveState():
-        if StateManager.saveBlocked == 0:
-            with StateManager.lock:
-                StateManager.threads = []
+        if StateManager.saveBlocked != 0:
+            return
 
-                def ExportAll(ref_diff):
-                    StateManager.state.update({"timestamp": time.time()})
+        with StateManager.lock:
+            try:
+                StateManager.DoSaveState()
+            except Exception as e:
+                # An export failure must never escape into a caller that is
+                # holding a save block: it would skip that caller's
+                # ReleaseSaving() and disable every future export.
+                logger.error(traceback.format_exc())
+
+    def DoSaveState():
+        StateManager.threads = []
+
+        def EncodeFallback(value):
+            # Without this a single value orjson can't handle would stop
+            # program_state.json from ever being written again.
+            logger.warning(
+                f"State contains a {type(value).__name__} value which isn't JSON "
+                "serializable; exporting it as text")
+            return str(value)
+
+        def ExportAll(ref_diff):
+            try:
+                StateManager.state.update({"timestamp": time.time()})
+                try:
+                    encoded = orjson.dumps(
+                        StateManager.state, default=EncodeFallback,
+                        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2)
+
+                    # Write to a temp file then atomically replace, so a concurrent
+                    # reader never sees a truncated file. On Windows the replace can
+                    # fail if the browser has the destination open; fall back to a
+                    # direct write in that case.
+                    tmp_path = "./out/program_state.json.tmp"
+                    with open(tmp_path, 'wb') as file:
+                        file.write(encoded)
                     try:
-                        encoded = orjson.dumps(
-                            StateManager.state, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2)
-
-                        # Write to a temp file then atomically replace, so a concurrent
-                        # reader never sees a truncated file. On Windows the replace can
-                        # fail if the browser has the destination open; fall back to a
-                        # direct write in that case.
-                        tmp_path = "./out/program_state.json.tmp"
-                        with open(tmp_path, 'wb') as file:
+                        os.replace(tmp_path, "./out/program_state.json")
+                    except PermissionError:
+                        os.remove(tmp_path)
+                        with open("./out/program_state.json", 'wb') as file:
                             file.write(encoded)
-                        try:
-                            os.replace(tmp_path, "./out/program_state.json")
-                        except PermissionError:
-                            os.remove(tmp_path)
-                            with open("./out/program_state.json", 'wb') as file:
-                                file.write(encoded)
-                    finally:
-                        StateManager.state.pop("timestamp", None)
+                finally:
+                    StateManager.state.pop("timestamp", None)
 
-                    if not SettingsManager.Get("general.disable_export", False):
-                        StateManager.ExportText(
-                            StateManager.lastSavedState, ref_diff)
-                    StateManager.lastSavedState = deep_clone(
-                        StateManager.state)
+                if not SettingsManager.Get("general.disable_export", False):
+                    StateManager.ExportText(
+                        StateManager.lastSavedState, ref_diff)
+                StateManager.lastSavedState = deep_clone(
+                    StateManager.state)
+            except Exception as e:
+                # This runs in its own thread; without this the traceback would
+                # only reach the thread excepthook.
+                logger.error(traceback.format_exc())
 
-                # logger.debug(StateManager.changedKeys)
+        # logger.debug(StateManager.changedKeys)
 
-                diff = DeepDiff(
-                    StateManager.lastSavedState,
-                    StateManager.state,
-                    exclude_types=[type(None)],
-                    include_paths=list(set(StateManager.changedKeys)),
-                    verbose_level=2, # Necessary to see values of added items.
-                )
+        changedKeys = list(set(StateManager.changedKeys))
+
+        # Cleared up front: a change we cannot diff must not be retried on every
+        # subsequent save, or a single bad key would stall the export for good.
+        StateManager.changedKeys = []
+
+        try:
+            diff = DeepDiff(
+                StateManager.lastSavedState,
+                StateManager.state,
+                exclude_types=[type(None)],
+                include_paths=changedKeys,
+                verbose_level=2, # Necessary to see values of added items.
+            )
+        except Exception as e:
+            logger.error(traceback.format_exc())
+            diff = None
+
+        if diff is not None:
+            try:
                 delta = Delta(diff).to_flat_dicts()
                 # logger.debug(f"State diff length: {diff_count}")
                 if len(delta) > 100:
                     StateManager.deltaIndex += 1
                     StateManager.signals.state_big_change.emit()
                 elif len(delta) > 0:
-                    try:
-                        StateManager.deltaIndex += 1
-                        StateManager.signals.state_updated.emit({
-                            'delta_index': StateManager.deltaIndex,
-                            'delta': Delta(diff).to_flat_dicts()
-                        })
-                    except TypeError:
-                        logger.warning(f"Couldn't serialize diff. Changed Keys: {StateManager.changedKeys}")
+                    StateManager.deltaIndex += 1
+                    StateManager.signals.state_updated.emit({
+                        'delta_index': StateManager.deltaIndex,
+                        'delta': delta
+                    })
+            except TypeError:
+                logger.warning(f"Couldn't serialize diff. Changed Keys: {changedKeys}")
+            except Exception as e:
+                logger.error(traceback.format_exc())
+                # Overlays can still resync from the full state.
+                StateManager.deltaIndex += 1
+                StateManager.signals.state_big_change.emit()
 
-                StateManager.changedKeys = []
+        # When the diff couldn't be computed we still export, so that
+        # program_state.json keeps tracking the live state.
+        if diff is None or len(diff) > 0:
+            exportThread = threading.Thread(
+                target=partial(ExportAll, ref_diff=diff if diff is not None else {}))
+            StateManager.threads.append(exportThread)
+            exportThread.start()
 
-                if len(diff) > 0:
-                    exportThread = threading.Thread(
-                        target=partial(ExportAll, ref_diff=diff))
-                    StateManager.threads.append(exportThread)
-                    exportThread.start()
-
-                    for t in StateManager.threads:
-                        t.join()
+            for t in StateManager.threads:
+                t.join()
 
     def LoadState():
         try:
@@ -159,6 +264,8 @@ class StateManager:
             if StateManager.saveBlocked == 0:
                 StateManager.SaveState()
                 # StateManager.ExportText(oldState)
+            else:
+                StateManager.CheckSaveBlockWatchdog()
 
     def Unset(key: str):
         # import inspect
@@ -178,6 +285,8 @@ class StateManager:
             if StateManager.saveBlocked == 0:
                 StateManager.SaveState()
                 # StateManager.ExportText(oldState)
+            else:
+                StateManager.CheckSaveBlockWatchdog()
 
     def Get(key: str, default=None):
         return deep_get(StateManager.state, key, default)

--- a/src/TSHBracketView.py
+++ b/src/TSHBracketView.py
@@ -418,8 +418,12 @@ class TSHBracketView(QGraphicsView):
 
         self.DrawLines()
 
-        StateManager.BlockSaving()
+        with StateManager.SaveBlock():
+            self.ExportBracketState()
 
+    def ExportBracketState(self):
+        # Exports the current bracket to the state. Meant to be called inside a
+        # StateManager.SaveBlock() so the whole bracket lands in a single save.
         data = {}
 
         StateManager.Set("bracket.bracket.progressionsIn",
@@ -458,13 +462,20 @@ class TSHBracketView(QGraphicsView):
                     continue
 
             # Get round name or placeholder name
-            if self.roundNameLabels.get(roundKey):
-                roundName = self.roundNameLabels.get(roundKey).text()
-                if roundName == "":
-                    roundName = self.roundNameLabels.get(
-                        roundKey).placeholderText()
-            else:
-                roundName = ""
+            roundName = ""
+            roundNameLabel = self.roundNameLabels.get(roundKey)
+            if roundNameLabel is not None:
+                try:
+                    roundName = roundNameLabel.text()
+                    if roundName == "":
+                        roundName = roundNameLabel.placeholderText()
+                except RuntimeError:
+                    # The label was destroyed by a bracket rebuild that happened
+                    # while this update was running; skip its name instead of
+                    # aborting the export.
+                    logger.warning(
+                        f"Round name label for round {roundKey} was deleted while exporting")
+                    roundName = ""
 
             # Limited export number cutout
             if int(roundKey) > 0:
@@ -542,8 +553,6 @@ class TSHBracketView(QGraphicsView):
                 }
 
         StateManager.Set("bracket.bracket.rounds", data)
-
-        StateManager.ReleaseSaving()
 
     def DrawLines(self):
         for element in self.bracketLines:

--- a/src/TSHBracketWidget.py
+++ b/src/TSHBracketWidget.py
@@ -31,12 +31,21 @@ class TSHBracketWidgetSignals(QObject):
 class TSHBracketWidget(QDockWidget):
     instance: "TSHBracketWidget" = None
     def __init__(self, *args):
-        StateManager.BlockSaving()
-        super().__init__(*args)
+        with StateManager.SaveBlock():
+            super().__init__(*args)
+            self.SetupUi()
 
+        TSHBracketWidget.instance = self
+
+    def SetupUi(self):
         uic.loadUi(TSHResolve("src/layout/TSHBracket.ui"), self)
 
         StateManager.Set("bracket", {})
+
+        # Guards against UpdatePhaseGroup being re-entered while it pumps the
+        # event loop; see UpdatePhaseGroup.
+        self.updatingPhaseGroup = False
+        self.pendingPhaseGroupData = None
 
         TSHTournamentDataProvider.instance.signals.tournament_phases_updated.connect(
             self.UpdatePhases)
@@ -208,10 +217,6 @@ class TSHBracketWidget(QDockWidget):
             self.SetDefaultsFromAssets
         )
 
-        StateManager.ReleaseSaving()
-        
-        TSHBracketWidget.instance = self
-
     def UpdatePhases(self, phases):
         logger.info("Phases: " + str(phases))
         self.phaseSelection.clear()
@@ -277,8 +282,37 @@ class TSHBracketWidget(QDockWidget):
                 _set.finished = False
 
     def UpdatePhaseGroup(self, phaseGroupData):
-        StateManager.BlockSaving()
-        self.playerList.signals.DataChanged.disconnect()
+        # This method pumps the event loop (processEvents) while it runs, so a
+        # second phase group payload can be delivered right in the middle of it.
+        # Re-entering would unbalance the DataChanged connection and the save
+        # block, so newer data is queued and applied after the current run.
+        if self.updatingPhaseGroup:
+            self.pendingPhaseGroupData = phaseGroupData
+            return
+
+        while True:
+            self.updatingPhaseGroup = True
+
+            try:
+                with StateManager.SaveBlock():
+                    self.ApplyPhaseGroup(phaseGroupData)
+            finally:
+                self.updatingPhaseGroup = False
+
+            if self.pendingPhaseGroupData is None:
+                break
+
+            phaseGroupData = self.pendingPhaseGroupData
+            self.pendingPhaseGroupData = None
+
+    def ApplyPhaseGroup(self, phaseGroupData):
+        try:
+            self.playerList.signals.DataChanged.disconnect(
+                self.bracketView.Update)
+            reconnectDataChanged = True
+        except TypeError:
+            # Nothing was connected; don't reconnect something we didn't unhook.
+            reconnectDataChanged = False
 
         try:
             logger.info("Phase Group Data: " + str(phaseGroupData))
@@ -307,7 +341,9 @@ class TSHBracketWidget(QDockWidget):
             # Make sure progressions are exported
             QGuiApplication.processEvents()
 
-            self.playerList.LoadFromStandings(phaseGroupData.get("entrants"))
+            entrants = phaseGroupData.get("entrants") or []
+
+            self.playerList.LoadFromStandings(entrants)
 
             # Wait for the player list to update
             QGuiApplication.processEvents()
@@ -321,12 +357,12 @@ class TSHBracketWidget(QDockWidget):
             self.playerPerTeam.blockSignals(False)
 
             self.RebuildBracket(
-                len(phaseGroupData.get("entrants")),
+                len(entrants),
                 phaseGroupData.get("seedMap"),
                 phaseGroupData.get("customSeeding", False)
             )
 
-            for r, round in phaseGroupData.get("sets", {}).items():
+            for r, round in (phaseGroupData.get("sets") or {}).items():
                 for s, _set in enumerate(round):
                     try:
                         score = _set.get("score")
@@ -349,9 +385,9 @@ class TSHBracketWidget(QDockWidget):
         except:
             logger.error(traceback.format_exc())
         finally:
-            StateManager.ReleaseSaving()
-            self.playerList.signals.DataChanged.connect(
-                self.bracketView.Update)
+            if reconnectDataChanged:
+                self.playerList.signals.DataChanged.connect(
+                    self.bracketView.Update)
 
     def SetDefaultsFromAssets(self):
         if StateManager.Get(f'game.defaults'):

--- a/src/TSHIndividualGameTracker.py
+++ b/src/TSHIndividualGameTracker.py
@@ -313,29 +313,26 @@ class TSHIndividualGameTracker(QWidget):
 
 
     def SetStage(self, index=0, stage_codename=None):
-        StateManager.BlockSaving()
-        print(f"Setting stage for game {index+1}")
-        if self.stage_widget_list:
-            target = self.findChild(QComboBox, f"stageMenu_{index}")
-            if stage_codename:
-                for i in range(1, TSHGameAssetManager.instance.stageModelWithBlank.rowCount()):
-                    current_menu_item_data = TSHGameAssetManager.instance.stageModelWithBlank.item(i).data(Qt.ItemDataRole.UserRole)
-                    if current_menu_item_data.get("codename") in stage_codename:
-                        print(i, stage_codename)
-                        target.setCurrentIndex(i)
-                        target.currentIndexChanged.emit(i)
-            else:
-                target.setCurrentIndex(0)
-                target.currentIndexChanged.emit(0)
-        
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            print(f"Setting stage for game {index+1}")
+            if self.stage_widget_list:
+                target = self.findChild(QComboBox, f"stageMenu_{index}")
+                if stage_codename:
+                    for i in range(1, TSHGameAssetManager.instance.stageModelWithBlank.rowCount()):
+                        current_menu_item_data = TSHGameAssetManager.instance.stageModelWithBlank.item(i).data(Qt.ItemDataRole.UserRole)
+                        if current_menu_item_data.get("codename") in stage_codename:
+                            print(i, stage_codename)
+                            target.setCurrentIndex(i)
+                            target.currentIndexChanged.emit(i)
+                else:
+                    target.setCurrentIndex(0)
+                    target.currentIndexChanged.emit(0)
 
     def ResetAllStages(self):
-        StateManager.BlockSaving()
-        print(f"Reset all stages in the game tracker")
-        if self.stage_widget_list:
-            for index in range(len(self.stage_widget_list)):
-                target = self.findChild(QComboBox, f"stageMenu_{index}")
-                target.setCurrentIndex(0)
-                target.currentIndexChanged.emit(0)
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            print(f"Reset all stages in the game tracker")
+            if self.stage_widget_list:
+                for index in range(len(self.stage_widget_list)):
+                    target = self.findChild(QComboBox, f"stageMenu_{index}")
+                    target.setCurrentIndex(0)
+                    target.currentIndexChanged.emit(0)

--- a/src/TSHPlayerList.py
+++ b/src/TSHPlayerList.py
@@ -17,9 +17,11 @@ class TSHPlayerListWidgetSignals(QObject):
 
 class TSHPlayerList(QWidget):
     def __init__(self, *args, base="player_list"):
-        StateManager.BlockSaving()
-        super().__init__(*args)
+        with StateManager.SaveBlock():
+            super().__init__(*args)
+            self.SetupUi(base)
 
+    def SetupUi(self, base):
         self.signals = TSHPlayerListWidgetSignals()
 
         self.base = base
@@ -47,7 +49,6 @@ class TSHPlayerList(QWidget):
         self.layout().addWidget(scrollArea)
 
         StateManager.Set(base, {})
-        StateManager.ReleaseSaving()
 
     def ChildDataChangedEmit(self):
         if not self.childDataChangedLock:
@@ -58,20 +59,30 @@ class TSHPlayerList(QWidget):
             self.slotNumber.value(), self.signals.UpdateData)
 
     def LoadFromStandings(self, data):
-        StateManager.BlockSaving()
-        if len(data) > 0:
-            self.SetSlotNumber(len(data))
-            playerNumber = len(data[0].get("players"))
-            self.SetPlayersPerTeam(playerNumber)
+        data = data or []
 
-            self.childDataChangedLock = True
-            for i, slot in enumerate(self.slotWidgets):
-                slot.SetTeamData(data[i])
-            self.childDataChangedLock = False
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            if len(data) > 0:
+                self.SetSlotNumber(len(data))
+                playerNumber = len(data[0].get("players") or [])
+                self.SetPlayersPerTeam(playerNumber)
+
+                self.childDataChangedLock = True
+                try:
+                    for i, slot in enumerate(self.slotWidgets):
+                        # SetSlotNumber can leave a different amount of slots
+                        # than there is data (e.g. a slot failed to be removed)
+                        if i >= len(data):
+                            break
+                        slot.SetTeamData(data[i])
+                finally:
+                    self.childDataChangedLock = False
 
     def SetSlotNumber(self, number):
-        StateManager.BlockSaving()
+        with StateManager.SaveBlock():
+            self.DoSetSlotNumber(number)
+
+    def DoSetSlotNumber(self, number):
         while len(self.slotWidgets) < number:
             s = TSHPlayerListSlotWidget(
                 len(self.slotWidgets)+1, self, base=self.base)
@@ -98,18 +109,17 @@ class TSHPlayerList(QWidget):
 
         self.signals.DataChanged.emit()
 
-        StateManager.ReleaseSaving()
-
     def SetCharactersPerPlayer(self, value):
         # logger.info("TSHPlayerList#SetCharactersPerPlayer")
         self.charactersPerPlayer = value
-        StateManager.BlockSaving()
-        self.childDataChangedLock = True
-        for s in self.slotWidgets:
-            s.SetCharacterNumber(value)
-        self.childDataChangedLock = False
-        self.signals.DataChanged.emit()
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            self.childDataChangedLock = True
+            try:
+                for s in self.slotWidgets:
+                    s.SetCharacterNumber(value)
+            finally:
+                self.childDataChangedLock = False
+            self.signals.DataChanged.emit()
 
     def SetScoresVisible(self, value):
         for s in self.slotWidgets:
@@ -121,10 +131,11 @@ class TSHPlayerList(QWidget):
     def SetPlayersPerTeam(self, number):
         # logger.info("TSHPlayerList#SetPlayersPerTeam")
         self.playersPerTeam = number
-        StateManager.BlockSaving()
-        self.childDataChangedLock = True
-        for s in self.slotWidgets:
-            s.SetPlayersPerTeam(number)
-        self.childDataChangedLock = False
-        self.signals.DataChanged.emit()
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            self.childDataChangedLock = True
+            try:
+                for s in self.slotWidgets:
+                    s.SetPlayersPerTeam(number)
+            finally:
+                self.childDataChangedLock = False
+            self.signals.DataChanged.emit()

--- a/src/TSHPlayerListSlotWidget.py
+++ b/src/TSHPlayerListSlotWidget.py
@@ -75,33 +75,8 @@ class TSHPlayerListSlotWidget(QGroupBox):
     def SetPlayersPerTeam(self, number):
         # logger.info(f"TSHPlayerListSlotWidget#SetPlayersPerTeam({number})")
         if number != len(self.playerWidgets):
-            StateManager.BlockSaving()
-            while len(self.playerWidgets) < number:
-                p = TSHScoreboardPlayerWidget(
-                    index=len(self.playerWidgets)+1, teamNumber=1, path=f'{self.base}.slot.{self.index}.player.{len(self.playerWidgets)+1}')
-                self.playerWidgets.append(p)
-                self.list.layout().addWidget(p)
-
-                p.SetCharactersPerPlayer(self.playerList.charactersPerPlayer)
-
-                index = len(self.playerWidgets)-1
-
-                p.btMoveUp.clicked.connect(lambda x=None, index=index, p=p: p.SwapWith(
-                    self.playerWidgets[max(0, self.playerWidgets.index(p) - 1)]))
-                p.btMoveDown.clicked.connect(lambda x=None, index=index, p=p: p.SwapWith(
-                    self.playerWidgets[min(len(self.playerWidgets) - 1, self.playerWidgets.index(p) + 1)]))
-
-                p.instanceSignals.dataChanged.connect(
-                    self.ChildDataChangedEmit)
-
-            while len(self.playerWidgets) > number:
-                p = self.playerWidgets[-1]
-                p.setParent(None)
-                self.playerWidgets.remove(p)
-                StateManager.Unset(p.path)
-                p.deleteLater()
-
-            StateManager.ReleaseSaving()
+            with StateManager.SaveBlock():
+                self.DoSetPlayersPerTeam(number)
 
         # if number > 1:
         #     self.team1column.findChild(QLineEdit, "teamName").setVisible(True)
@@ -112,52 +87,84 @@ class TSHPlayerListSlotWidget(QGroupBox):
         #     self.team2column.findChild(QLineEdit, "teamName").setVisible(False)
         #     self.team2column.findChild(QLineEdit, "teamName").setText("")
 
+    def DoSetPlayersPerTeam(self, number):
+        while len(self.playerWidgets) < number:
+            p = TSHScoreboardPlayerWidget(
+                index=len(self.playerWidgets)+1, teamNumber=1, path=f'{self.base}.slot.{self.index}.player.{len(self.playerWidgets)+1}')
+            self.playerWidgets.append(p)
+            self.list.layout().addWidget(p)
+
+            p.SetCharactersPerPlayer(self.playerList.charactersPerPlayer)
+
+            index = len(self.playerWidgets)-1
+
+            p.btMoveUp.clicked.connect(lambda x=None, index=index, p=p: p.SwapWith(
+                self.playerWidgets[max(0, self.playerWidgets.index(p) - 1)]))
+            p.btMoveDown.clicked.connect(lambda x=None, index=index, p=p: p.SwapWith(
+                self.playerWidgets[min(len(self.playerWidgets) - 1, self.playerWidgets.index(p) + 1)]))
+
+            p.instanceSignals.dataChanged.connect(
+                self.ChildDataChangedEmit)
+
+        while len(self.playerWidgets) > number:
+            p = self.playerWidgets[-1]
+            p.setParent(None)
+            self.playerWidgets.remove(p)
+            StateManager.Unset(p.path)
+            p.deleteLater()
+
     def ChildDataChangedEmit(self):
         if not self.childDataChangedLock:
             self.signals.dataChanged.emit()
 
     def SetCharacterNumber(self, value):
         # logger.info(f"TSHPlayerListSlotWidget#SetCharacterNumber({value})")
-        StateManager.BlockSaving()
-        for pw in self.playerWidgets:
-            pw.SetCharactersPerPlayer(value)
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            for pw in self.playerWidgets:
+                pw.SetCharactersPerPlayer(value)
 
     def SetTeamData(self, data):
-        StateManager.BlockSaving()
-        self.childDataChangedLock = True
-        if (data.get("name")):
-            self.slotName.setText(data.get("name"))
-            self.slotName.editingFinished.emit()
-        else:
-            self.slotName.setText("")
-            self.slotName.editingFinished.emit()
-            
-        StateManager.Set(f"{self.base}.slot.{self.index}.wins", data.get("wins"))
-        StateManager.Set(f"{self.base}.slot.{self.index}.loses", data.get("losses"))
-        StateManager.Set(f"{self.base}.slot.{self.index}.winPercentage", data.get("winPercentage"))
+        data = data or {}
 
-        for i, pw in enumerate(self.playerWidgets):
-            if data.get("players"):
-                try:
-                    data.get("players")[i]["wins"] = data.get("wins")
-                    data.get("players")[i]["losses"] = data.get("losses")
-                    data.get("players")[i]["winPercentage"] = data.get("winPercentage")
-                    pw.SetData(data.get("players")[i])
-                except:
-                    pw.Clear()
-                    logger.error(traceback.format_exc())
-            else:
-                pw.Clear()
-        StateManager.ReleaseSaving()
-        self.childDataChangedLock = False
+        try:
+            with StateManager.SaveBlock():
+                self.childDataChangedLock = True
+
+                if (data.get("name")):
+                    self.slotName.setText(data.get("name"))
+                    self.slotName.editingFinished.emit()
+                else:
+                    self.slotName.setText("")
+                    self.slotName.editingFinished.emit()
+
+                StateManager.Set(f"{self.base}.slot.{self.index}.wins", data.get("wins"))
+                StateManager.Set(f"{self.base}.slot.{self.index}.loses", data.get("losses"))
+                StateManager.Set(f"{self.base}.slot.{self.index}.winPercentage", data.get("winPercentage"))
+
+                for i, pw in enumerate(self.playerWidgets):
+                    if data.get("players"):
+                        try:
+                            data.get("players")[i]["wins"] = data.get("wins")
+                            data.get("players")[i]["losses"] = data.get("losses")
+                            data.get("players")[i]["winPercentage"] = data.get("winPercentage")
+                            pw.SetData(data.get("players")[i])
+                        except:
+                            pw.Clear()
+                            logger.error(traceback.format_exc())
+                    else:
+                        pw.Clear()
+        finally:
+            self.childDataChangedLock = False
+
         self.signals.dataChanged.emit()
 
     def Clear(self):
-        StateManager.BlockSaving()
-        self.childDataChangedLock = True
-        for i, pw in enumerate(self.playerWidgets):
-            pw.Clear()
-        self.childDataChangedLock = False
-        StateManager.ReleaseSaving()
+        try:
+            with StateManager.SaveBlock():
+                self.childDataChangedLock = True
+                for i, pw in enumerate(self.playerWidgets):
+                    pw.Clear()
+        finally:
+            self.childDataChangedLock = False
+
         self.signals.dataChanged.emit()

--- a/src/TSHPlayerListWidget.py
+++ b/src/TSHPlayerListWidget.py
@@ -22,9 +22,11 @@ class TSHPlayerListWidgetSignals(QObject):
 
 class TSHPlayerListWidget(QDockWidget):
     def __init__(self, *args, base="player_list"):
-        StateManager.BlockSaving()
-        super().__init__(*args)
+        with StateManager.SaveBlock():
+            super().__init__(*args)
+            self.SetupUi(base)
 
+    def SetupUi(self, base):
         self.signals = TSHPlayerListWidgetSignals()
 
         self.playerList = TSHPlayerList(base=base)
@@ -116,8 +118,6 @@ class TSHPlayerListWidget(QDockWidget):
         TSHGameAssetManager.instance.signals.onLoad.connect(
             self.SetDefaultsFromAssets
         )
-
-        StateManager.ReleaseSaving()
 
     def LoadFromStandingsClicked(self):
         TSHTournamentDataProvider.instance.GetStandings(

--- a/src/TSHScoreboardManager.py
+++ b/src/TSHScoreboardManager.py
@@ -39,9 +39,11 @@ class TSHScoreboardManager(QDockWidget):
         self.scoreboardholder = []
 
     def UpdateAmount(self, amount):
-        StateManager.BlockSaving()
-
+        # BlockSaving() lives inside the try so that the finally below always
+        # releases it, even if one of the calls in between raises.
         try:
+            StateManager.BlockSaving()
+
             if amount > len(self.scoreboardholder):
                 logger.info(
                     "Scoreboard Manager - Creating Scoreboard " + str(amount))

--- a/src/TSHScoreboardPlayerWidget.py
+++ b/src/TSHScoreboardPlayerWidget.py
@@ -547,8 +547,10 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         self.CharactersChanged(includeMains=True)
 
     def SwapCharacters(self, index1: int, index2: int):
-        StateManager.BlockSaving()
+        with StateManager.SaveBlock():
+            self.DoSwapCharacters(index1, index2)
 
+    def DoSwapCharacters(self, index1: int, index2: int):
         if index2 > len(self.character_elements)-1:
             index2 = 0
 
@@ -581,8 +583,6 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         char2[2].setCurrentIndex(tmp[1])
 
         self.CharactersChanged()
-
-        StateManager.ReleaseSaving()
 
     def LoadControllers(self):
         try:
@@ -747,11 +747,14 @@ class TSHScoreboardPlayerWidget(QGroupBox):
 
     def SetData(self, data, dontLoadFromDB=False, clear=True, no_mains=False):
         self.dataLock.acquire()
-        StateManager.BlockSaving()
 
         logger.debug(f"Setting data for {self.path}: {data}")
 
+        # BlockSaving() lives inside the try so that the finally below always
+        # releases it, even if one of the calls in between raises.
         try:
+            StateManager.BlockSaving()
+
             if clear:
                 self.Clear(no_mains=no_mains)
 
@@ -1037,7 +1040,10 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         TSHPlayerDB.DeletePlayer(tag)
 
     def Clear(self, no_mains=False):
-        StateManager.BlockSaving()
+        with StateManager.SaveBlock():
+            self.DoClear(no_mains=no_mains)
+
+    def DoClear(self, no_mains=False):
         with self.dataLock:
             for c in self.findChildren(QLineEdit):
                 if c.objectName() != "" and c.objectName() != 'qt_spinbox_lineedit':
@@ -1070,7 +1076,6 @@ class TSHScoreboardPlayerWidget(QGroupBox):
         StateManager.Unset(f"{self.path}.wins")
         StateManager.Unset(f"{self.path}.losses")
         StateManager.Unset(f"{self.path}.winPercentage")
-        StateManager.ReleaseSaving()
 
     def SetRomanizedText(self):
         name = self.findChild(QWidget, "name").text()

--- a/src/TSHScoreboardWidget.py
+++ b/src/TSHScoreboardWidget.py
@@ -362,11 +362,8 @@ class TSHScoreboardWidget(QWidget):
         self.colorButton1 = TSHColorButton(color=DEFAULT_TEAM1_COLOR)
         # self.colorButton1.setText(QApplication.translate("app", "COLOR"))
         self.colorButton1.colorChanged.connect(
-            lambda color: [
-                StateManager.BlockSaving(),
-                StateManager.Set(f"score.{self.scoreboardNumber}.team.1.color", color),
-                StateManager.ReleaseSaving()
-            ])
+            lambda color: StateManager.Set(
+                f"score.{self.scoreboardNumber}.team.1.color", color))
         self.CommandTeamColor(0, DEFAULT_TEAM1_COLOR)
 
         self.colorMenu1 = QComboBox()
@@ -425,11 +422,8 @@ class TSHScoreboardWidget(QWidget):
         DEFAULT_TEAM2_COLOR = SettingsManager.Get("general.team_2_default_color", "#2e89ff")
         self.colorButton2 = TSHColorButton(color=DEFAULT_TEAM2_COLOR)
         self.colorButton2.colorChanged.connect(
-            lambda color: [
-                StateManager.BlockSaving(),
-                StateManager.Set(f"score.{self.scoreboardNumber}.team.2.color", color),
-                StateManager.ReleaseSaving()
-            ])
+            lambda color: StateManager.Set(
+                f"score.{self.scoreboardNumber}.team.2.color", color))
         # self.colorButton2.setText(QApplication.translate("app", "COLOR"))
         self.CommandTeamColor(1, DEFAULT_TEAM2_COLOR)
 
@@ -504,24 +498,7 @@ class TSHScoreboardWidget(QWidget):
         self.individualGameTracker.signals.stageResultsUpdate.connect(self.StageResultsToScore)
         
         self.scoreColumn.findChild(QSpinBox, "best_of").valueChanged.connect(
-            lambda value: [
-                StateManager.BlockSaving(),
-                StateManager.Set(
-                    f"score.{self.scoreboardNumber}.best_of", value),
-                StateManager.Set(
-                    f"score.{self.scoreboardNumber}.best_of_short_text", f"BO{value}"),
-                StateManager.Set(f"score.{self.scoreboardNumber}.best_of_text", TSHLocaleHelper.matchNames.get(
-                    "best_of").format(value) if value > 0 else ""),
-                StateManager.Set(
-                    f"score.{self.scoreboardNumber}.first_to", math.ceil(value/2)),
-                StateManager.Set(
-                    f"score.{self.scoreboardNumber}.first_to_short_text", f"FT{math.ceil(value/2)}"),
-                StateManager.Set(f"score.{self.scoreboardNumber}.first_to_text", TSHLocaleHelper.matchNames.get(
-                    "first_to").format(math.ceil(value/2)) if value > 0 else ""),
-                self.individualGameTracker.SetStageCount(value),
-                StateManager.ReleaseSaving()
-            ]
-        )
+            self.ExportBestOf)
         self.scoreColumn.findChild(QSpinBox, "best_of").valueChanged.emit(0)
 
         self.scoreColumn.findChild(QSpinBox, "score_left").valueChanged.connect(
@@ -586,6 +563,22 @@ class TSHScoreboardWidget(QWidget):
 
         self.scoreColumn.findChild(QVBoxLayout, "verticalLayout").addWidget(self.individualGameTracker)
 
+
+    def ExportBestOf(self, value):
+        with StateManager.SaveBlock():
+            StateManager.Set(
+                f"score.{self.scoreboardNumber}.best_of", value)
+            StateManager.Set(
+                f"score.{self.scoreboardNumber}.best_of_short_text", f"BO{value}")
+            StateManager.Set(f"score.{self.scoreboardNumber}.best_of_text", TSHLocaleHelper.matchNames.get(
+                "best_of").format(value) if value > 0 else "")
+            StateManager.Set(
+                f"score.{self.scoreboardNumber}.first_to", math.ceil(value/2))
+            StateManager.Set(
+                f"score.{self.scoreboardNumber}.first_to_short_text", f"FT{math.ceil(value/2)}")
+            StateManager.Set(f"score.{self.scoreboardNumber}.first_to_text", TSHLocaleHelper.matchNames.get(
+                "first_to").format(math.ceil(value/2)) if value > 0 else "")
+            self.individualGameTracker.SetStageCount(value)
 
     def StageResultsToScore(self, team_1_score, team_2_score):
         with QSignalBlocker(self.scoreColumn.findChild(QSpinBox, "score_left")):
@@ -807,13 +800,15 @@ class TSHScoreboardWidget(QWidget):
             self.ToggleElements(action, element[1])
 
     def SwapTeams(self):
-        StateManager.BlockSaving()
-
         # Lock all player widgets
         for p in self.playerWidgets:
             p.dataLock.acquire()
 
+        # BlockSaving() lives inside the try so that the finally below always
+        # releases it, even if one of the calls in between raises.
         try:
+            StateManager.BlockSaving()
+
             for i, p in enumerate(self.team1playerWidgets):
                 p.SwapWith(self.team2playerWidgets[i])
 
@@ -870,11 +865,8 @@ class TSHScoreboardWidget(QWidget):
 
         logger.info("STATION SETS LOADED -----------------------------")
         logger.info(data)
-        StateManager.BlockSaving()
 
         StateManager.Set(f"score.{self.scoreboardNumber}.station_queue", data)
-
-        StateManager.ReleaseSaving()
 
     def NewSetSelected(self, data):
         if not SettingsManager.Get("general.disable_autoupdate", False):
@@ -906,9 +898,12 @@ class TSHScoreboardWidget(QWidget):
         # Lock all player widgets
         for p in self.playerWidgets:
             p.dataLock.acquire()
-        StateManager.BlockSaving()
 
+        # BlockSaving() lives inside the try so that the finally below always
+        # releases it, even if one of the calls in between raises.
         try:
+            StateManager.BlockSaving()
+
             TSHTournamentDataProvider.instance.GetStreamQueue()
 
             if data.get("id") != None and data.get("id") != self.lastSetSelected:
@@ -1079,10 +1074,8 @@ class TSHScoreboardWidget(QWidget):
                 if team == 1:
                     self.colorButton2.setColor(value)
                 if team in (0, 1):
-                    StateManager.BlockSaving()
                     StateManager.Set(
                         f"score.{self.scoreboardNumber}.team.{team + 1}.color", value)
-                    StateManager.ReleaseSaving()
                 
                 # Set in menu if recognized
                 if type(color) is int and force_opponent:
@@ -1097,13 +1090,15 @@ class TSHScoreboardWidget(QWidget):
 
     # Modifies the current set data. Does not check for id, so do not call this with data that may lead to another hbox incident
     def ChangeSetData(self, data):
-        StateManager.BlockSaving()
-
-        StateManager.Set(f"score.{self.scoreboardNumber}.phase_size", data.get("numSeeds"))
-        StateManager.Set(f"score.{self.scoreboardNumber}.num_groups", data.get("groupCount"))
-        StateManager.Set(f"score.{self.scoreboardNumber}.round", data.get("round"))
-
+        # BlockSaving() lives inside the try so that the finally below always
+        # releases it, even if one of the calls in between raises.
         try:
+            StateManager.BlockSaving()
+
+            StateManager.Set(f"score.{self.scoreboardNumber}.phase_size", data.get("numSeeds"))
+            StateManager.Set(f"score.{self.scoreboardNumber}.num_groups", data.get("groupCount"))
+            StateManager.Set(f"score.{self.scoreboardNumber}.round", data.get("round"))
+
             round_name = data.get("round_name")
             if round_name:
                 self.scoreColumn.findChild(

--- a/src/TSHStatsUtil.py
+++ b/src/TSHStatsUtil.py
@@ -106,26 +106,25 @@ class TSHStatsUtil:
                 StateManager.Set(f"score.{self.scoreboardNumber}.last_sets.2", {})
 
     def UpdateLastSets(self, data):
-        StateManager.BlockSaving()
-        i = 1
-        for set in data.get("last_sets", []):
-            StateManager.Set(f"score.{self.scoreboardNumber}.last_sets." + data.get("playerNumber") + "." + str(i), {
-                "phase_id": set.get("phase_id"),
-                "phase_name": set.get("phase_name"),
-                "round_name": set.get("round_name"),
-                "player_score": set.get("player1_score"),
-                "player_seed": set.get("player1_seed"),
-                "player_team": set.get("player1_team"),
-                "player_name": set.get("player1_name"),
-                "player_char": set.get("player_char", {}),
-                "oponent_score": set.get("player2_score"),
-                "oponent_seed": set.get("player2_seed"),
-                "oponent_team": set.get("player2_team"),
-                "oponent_name": set.get("player2_name"),
-                "oponent_char": set.get("oponent_char", {}),
-            })
-            i += 1
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            i = 1
+            for set in data.get("last_sets", []):
+                StateManager.Set(f"score.{self.scoreboardNumber}.last_sets." + data.get("playerNumber") + "." + str(i), {
+                    "phase_id": set.get("phase_id"),
+                    "phase_name": set.get("phase_name"),
+                    "round_name": set.get("round_name"),
+                    "player_score": set.get("player1_score"),
+                    "player_seed": set.get("player1_seed"),
+                    "player_team": set.get("player1_team"),
+                    "player_name": set.get("player1_name"),
+                    "player_char": set.get("player_char", {}),
+                    "oponent_score": set.get("player2_score"),
+                    "oponent_seed": set.get("player2_seed"),
+                    "oponent_team": set.get("player2_team"),
+                    "oponent_name": set.get("player2_name"),
+                    "oponent_char": set.get("oponent_char", {}),
+                })
+                i += 1
 
     def GetPlayerHistoryStandingsP1(self):
         # Only if 1 player on each side
@@ -148,21 +147,20 @@ class TSHStatsUtil:
                 StateManager.Set(f"score.{self.scoreboardNumber}.history_sets.2", {})
 
     def UpdateHistorySets(self, data):
-        StateManager.BlockSaving()
-        i = 1
-        for set in data.get("history_sets", []):
-            StateManager.Set(f"score.{self.scoreboardNumber}.history_sets." + data.get("playerNumber") + "." + str(i), {
-                "placement": set.get("placement"),
-                "event_name": set.get("event_name"),
-                "tournament_name": set.get("tournament_name"),
-                "tournament_picture": set.get("tournament_picture"),
-                "entrants": set.get("entrants"),
-                "event_date_month": datetime.fromtimestamp(set.get("event_date")).strftime("%B"),
-                "event_date_day": datetime.fromtimestamp(set.get("event_date")).strftime("%d"),
-                "event_date_year": datetime.fromtimestamp(set.get("event_date")).strftime("%Y")
-            })
-            i += 1
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            i = 1
+            for set in data.get("history_sets", []):
+                StateManager.Set(f"score.{self.scoreboardNumber}.history_sets." + data.get("playerNumber") + "." + str(i), {
+                    "placement": set.get("placement"),
+                    "event_name": set.get("event_name"),
+                    "tournament_name": set.get("tournament_name"),
+                    "tournament_picture": set.get("tournament_picture"),
+                    "entrants": set.get("entrants"),
+                    "event_date_month": datetime.fromtimestamp(set.get("event_date")).strftime("%B"),
+                    "event_date_day": datetime.fromtimestamp(set.get("event_date")).strftime("%d"),
+                    "event_date_year": datetime.fromtimestamp(set.get("event_date")).strftime("%Y")
+                })
+                i += 1
 
     def GetSetUpsetFactor(self):
         if len(self.scoreboard.team1playerWidgets) == 1:
@@ -190,13 +188,10 @@ class TSHStatsUtil:
         pass
 
     def UpdateStreamQueue(self, data):
-        StateManager.BlockSaving()
-
-        StateManager.Set(f"streamQueue", data)
-        StateManager.Set(f"currentStream",
-                         SettingsManager.Get("twitch_username"))
-
-        StateManager.ReleaseSaving()
+        with StateManager.SaveBlock():
+            StateManager.Set(f"streamQueue", data)
+            StateManager.Set(f"currentStream",
+                             SettingsManager.Get("twitch_username"))
 
     # Calculation of Seeding/Placement to determine
     # Upset Factor or Seeding Performance Rating

--- a/src/TSHTeamBattleWidget.py
+++ b/src/TSHTeamBattleWidget.py
@@ -191,11 +191,7 @@ class TSHTeamBattleWidget(QDockWidget):
         self.colorButton1 = TSHColorButton(color=DEFAULT_TEAM1_COLOR, ignore_same_color=False)
         self.team1column.findChild(QHBoxLayout, "team_header").layout().insertWidget(0, self.colorButton1)
         self.colorButton1.colorChanged.connect(
-            lambda color: [
-                StateManager.BlockSaving(),
-                StateManager.Set(f"team_battle.team.{1}.color", color),
-                StateManager.ReleaseSaving()
-            ])
+            lambda color: StateManager.Set(f"team_battle.team.{1}.color", color))
         self.colorButton1.setColor(DEFAULT_TEAM1_COLOR)
         self.team1score = QSpinBox()
         self.team1column.findChild(QHBoxLayout, "team_header").layout().addWidget(self.team1score)
@@ -211,11 +207,7 @@ class TSHTeamBattleWidget(QDockWidget):
         self.colorButton2 = TSHColorButton(color=DEFAULT_TEAM2_COLOR, ignore_same_color=False)
         self.team2column.findChild(QHBoxLayout, "team_header").layout().insertWidget(0, self.colorButton2)
         self.colorButton2.colorChanged.connect(
-            lambda color: [
-                StateManager.BlockSaving(),
-                StateManager.Set(f"team_battle.team.{2}.color", color),
-                StateManager.ReleaseSaving()
-            ])
+            lambda color: StateManager.Set(f"team_battle.team.{2}.color", color))
         self.colorButton2.setColor(DEFAULT_TEAM2_COLOR)
         self.team2score = QSpinBox()
         self.team2column.findChild(QHBoxLayout, "team_header").layout().addWidget(self.team2score)

--- a/src/TSHTeamPlayerWidget.py
+++ b/src/TSHTeamPlayerWidget.py
@@ -601,8 +601,10 @@ class TSHTeamPlayerWidget(QGroupBox):
         self.CharactersChanged(includeMains=True)
 
     def SwapCharacters(self, index1: int, index2: int):
-        StateManager.BlockSaving()
+        with StateManager.SaveBlock():
+            self.DoSwapCharacters(index1, index2)
 
+    def DoSwapCharacters(self, index1: int, index2: int):
         if index2 > len(self.character_elements)-1:
             index2 = 0
 
@@ -635,8 +637,6 @@ class TSHTeamPlayerWidget(QGroupBox):
         char2[2].setCurrentIndex(tmp[1])
 
         self.CharactersChanged()
-
-        StateManager.ReleaseSaving()
 
     def LoadCountries(self):
         try:
@@ -750,11 +750,14 @@ class TSHTeamPlayerWidget(QGroupBox):
 
     def SetData(self, data, dontLoadFromDB=False, clear=True, no_mains=False):
         self.dataLock.acquire()
-        StateManager.BlockSaving()
 
         logger.debug(f"Setting data for {self.path}: {data}")
 
+        # BlockSaving() lives inside the try so that the finally below always
+        # releases it, even if one of the calls in between raises.
         try:
+            StateManager.BlockSaving()
+
             if clear:
                 self.Clear(no_mains=no_mains)
 
@@ -929,7 +932,10 @@ class TSHTeamPlayerWidget(QGroupBox):
         return prefix+" "+gamerTag if prefix else gamerTag
 
     def Clear(self, no_mains=False):
-        StateManager.BlockSaving()
+        with StateManager.SaveBlock():
+            self.DoClear(no_mains=no_mains)
+
+    def DoClear(self, no_mains=False):
         with self.dataLock:
             for c in self.findChildren(QLineEdit):
                 if c.objectName() != "" and c.objectName() != 'qt_spinbox_lineedit':
@@ -957,4 +963,3 @@ class TSHTeamPlayerWidget(QGroupBox):
                         continue  # only executed if the inner loop DID break
                 else:
                     c.setCurrentIndex(0)
-        StateManager.ReleaseSaving()

--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -318,8 +318,17 @@ class Window(QMainWindow):
         super().__init__()
 
         StateManager.loop = loop
-        StateManager.BlockSaving()
 
+        # Startup is expected to hold the block for a long time, so it opts out
+        # of the stuck-block watchdog.
+        with StateManager.SaveBlock(watchdog=False):
+            self.SetupUi()
+
+        TSHScoreboardManager.instance.signals.ScoreboardAmountChanged.connect(
+            self.ToggleTopOption)
+        StateManager.Unset("completed_sets")
+
+    def SetupUi(self):
         TSHLocaleHelper.LoadLocale()
         TSHLocaleHelper.LoadRoundNames()
         self.LoadTheme()
@@ -913,12 +922,6 @@ class Window(QMainWindow):
             self.webserver.ws_playerdb
         )
         TSHPlayerDB.LoadDB()
-
-        StateManager.ReleaseSaving()
-
-        TSHScoreboardManager.instance.signals.ScoreboardAmountChanged.connect(
-            self.ToggleTopOption)
-        StateManager.Unset("completed_sets")
 
     def SetGame(self, mods_active = False):
         index = next((i for i in range(self.gameSelect.model().rowCount()) if self.gameSelect.itemText(i) == TSHGameAssetManager.instance.selectedGame.get(


### PR DESCRIPTION
StateManager.saveBlocked is a global counter and SaveState() only writes out/program_state.json when it is exactly 0. A single exception thrown between a BlockSaving() and its ReleaseSaving() left the counter stuck above 0, so every later block/release pair just oscillated and the JSON export, the out/ text files and the WebSocket deltas to the overlays all went silent until the app was restarted. In packaged builds the custom sys.excepthook swallows exceptions raised inside slots, so this failed without any visible sign.

StateManager:
- Take the lock in BlockSaving()/ReleaseSaving() and clamp the counter at 0 so an extra release can't break exports in the negative direction.
- Add a watchdog that force-releases and saves when saving has stayed blocked for longer than general.statemanager_block_timeout (30s), so a leak that slips through recovers itself and logs why. SaveBlock accepts watchdog=False for blocks that are meant to be long lived (startup).
- Wrap the save in try/except so an export failure can't escape into a caller that is holding a block.
- Clear changedKeys up front and tolerate a diff that can't be computed or flattened, so one bad key can't stall the export forever.
- Give orjson a default= fallback so one non-serializable value doesn't stop program_state.json from ever being written again.
- Reuse the already computed delta instead of flattening it twice.

Bracket widget (the most common trigger):
- TSHBracketView.Update, TSHBracketWidget.__init__ and UpdatePhaseGroup now block through SaveBlock().
- UpdatePhaseGroup pumps the event loop, so a second phase group payload could re-enter it; the no-arg DataChanged.disconnect() then raised TypeError before the try, leaking a block. It now guards against re-entrancy (queueing newer data), disconnects only its own slot, and tolerates it not being connected.
- Tolerate missing entrants/sets and round name labels destroyed by a rebuild that happened mid-export.

Player list, scoreboard, stats and startup: same unbalanced pattern converted to SaveBlock(), or BlockSaving() moved inside the existing try so the finally always releases it.